### PR TITLE
Updated Mac OS bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,9 +131,10 @@ NIX_LD_FLAGS = $(LD_FLAGS)
 NIX_C_FLAGS = $(C_FLAGS) -DLUA_USE_READLINE -DLUA_USE_LINUX
 ifdef IS_OSX
 BREW_PREFIX := $(shell brew --prefix)
-NIX_CPP_FLAGS += -mmacosx-version-min=10.12 -I$(BREW_PREFIX)/opt/openssl@1.1/include
-NIX_LD_FLAGS += -mmacosx-version-min=10.12 -L$(BREW_PREFIX)/opt/openssl@1.1/lib
-NIX_C_FLAGS += -mmacosx-version-min=10.12 -I$(BREW_PREFIX)/opt/openssl@1.1/include
+DEPLOYMENT_TARGET=10.12
+NIX_CPP_FLAGS += -mmacosx-version-min=$(DEPLOYMENT_TARGET) -I$(BREW_PREFIX)/opt/openssl@1.1/include
+NIX_LD_FLAGS += -mmacosx-version-min=$(DEPLOYMENT_TARGET) -L$(BREW_PREFIX)/opt/openssl@1.1/lib
+NIX_C_FLAGS += -mmacosx-version-min=$(DEPLOYMENT_TARGET) -I$(BREW_PREFIX)/opt/openssl@1.1/include
 endif
 
 # default target: "native"
@@ -232,7 +233,7 @@ $(WIN32_ZIP) $(WIN64_ZIP):
 	rm -rf $(TMP_DIR)
 
 $(OSX_APP): $(NIX_EXE)
-	./macosx/bundle_macosx_app.sh --version=$(VERSION) "$(NIX_EXE)"
+	./macosx/bundle_macosx_app.sh --version=$(VERSION) --deployment-target=$(DEPLOYMENT_TARGET) "$(NIX_EXE)"
 	
 $(OSX_ZIP): $(OSX_APP) | $(DIST_DIR)
 	rm -f $@

--- a/Makefile
+++ b/Makefile
@@ -337,3 +337,7 @@ clean:
 	if [[ -d $(WIN32_BUILD_DIR) && -z `ls -A $(WIN32_BUILD_DIR)` ]]; then rmdir $(WIN32_BUILD_DIR) ; fi
 	if [[ -d $(WIN64_BUILD_DIR) && -z `ls -A $(WIN64_BUILD_DIR)` ]]; then rmdir $(WIN64_BUILD_DIR) ; fi
 	if [[ -d $(BUILD_DIR) && -z `ls -A $(BUILD_DIR)` ]]; then rmdir $(BUILD_DIR) ; fi
+ifdef IS_OSX
+	./macosx/bundle_macosx_app.sh --clear-thirdparty-dirs
+endif
+

--- a/macosx/build_thirdparty.sh
+++ b/macosx/build_thirdparty.sh
@@ -93,7 +93,9 @@ fi
 
 cd $LIB_PNG_DEST_DIR
 
+git pull
 git checkout $LIB_PNG_TAG
+
 ./configure $CONFIGURE_FLAGS
 make
 
@@ -108,6 +110,7 @@ fi
 
 cd $LIB_FREETYPE_DEST_DIR
 
+git pull
 git checkout $LIB_FREETYPE_TAG
 
 ./autogen.sh
@@ -125,7 +128,9 @@ fi
 
 cd $LIB_SDL_DEST_DIR
 
+git pull
 git checkout $LIB_SDL_TAG
+
 ./configure $CONFIGURE_FLAGS
 make
 
@@ -141,7 +146,9 @@ fi
 
 cd $LIB_SDL_IMAGE_DEST_DIR
 
+git pull
 git checkout $LIB_SDL_IMAGE_TAG
+
 ./configure $CONFIGURE_FLAGS
 make
 
@@ -157,7 +164,9 @@ fi
 
 cd $LIB_SDL_TTF_DEST_DIR
 
+git pull
 git checkout $LIB_SDL_TTF_TAG
+
 ./configure $CONFIGURE_FLAGS
 make
 
@@ -172,7 +181,9 @@ fi
 
 cd $LIB_OPENSSL_DEST_DIR
 
+git pull
 git checkout $LIB_OPENSSL_TAG
+
 ./config $CONFIGURE_FLAGS
 make
 

--- a/macosx/bundle_macosx_app.sh
+++ b/macosx/bundle_macosx_app.sh
@@ -8,9 +8,11 @@ VERSION=
 BUNDLE_NAME_SET=no
 BUNDLE_NAME=
 APP_OWNER="com.evermizer"
+DEPLOYMENT_TARGET="10.12"
+BUILD_THIRD_PARTY=yes
 
 function usage() {
-  echo "Usage: `basename $0` [--version=] [--bundle-name=] binary"
+  echo "Usage: `basename $0` [--version=] [--bundle-name=] [--deployment-target=] [--do-not-build-thirdparty] binary"
 }
 
 if test $# -eq 0; then
@@ -31,6 +33,12 @@ while test $# -gt 0; do
     --bundle-name=*)
       BUNDLE_NAME=$optarg
       BUNDLE_NAME_SET=yes
+      ;;
+    --deployment-target=*)
+      DEPLOYMENT_TARGET=$optarg
+      ;;
+    --do-not-build-thirdparty)
+      BUILD_THIRD_PARTY=no
       ;;
     *)
       EXE=$1
@@ -97,34 +105,89 @@ cp $EXE $DST_EXE
 cp -r $SRC_ASSETS_DIR $APP_BUNDLE_MACOS_DIR
 cp -r $DOCS $APP_BUNDLE_MACOS_DIR
 
-# Update dynamic paths
+# Build third party libraries and update dynamic paths
 # This won't work with libraries installed with brew.
 
-# Temporary solution to retrieve the necessary libraries to produce a app bundle.
-# A more permanent solution would be to download, compile, and link against the sources directly.
-REPO_URL="https://github.com/sbzappa/prebuilt-sdl.git"
-PREBUILT_DIR="$SRC_DIR/prebuilt-sdl"
+BUILD_DIR="build"
+LIB_DIR="libs"
 
-[ -d $PREBUILT_DIR ] || git clone $REPO_URL $PREBUILT_DIR
-[ -d $PREBUILT_DIR ] || exit 1
+if test $BUILD_THIRD_PARTY = yes ; then
+  sh $SRC_DIR/build_thirdparty \
+    --deployment-target=$DEPLOYMENT_TARGET \
+    --BUILD_DIR=$BUILD_DIR \
+    --LIB_DIR=$LIB_DIR
+fi
 
 LIB_SDL2="libSDL2-2.0.0.dylib"
 LIB_SDL2_IMAGE="libSDL2_image-2.0.0.dylib"
 LIB_SDL2_TTF="libSDL2_ttf-2.0.0.dylib"
 LIB_FREETYPE="libfreetype.6.dylib"
 LIB_PNG="libpng16.16.dylib"
+LIB_OPENSSL="libssl.1.1.dylib"
+LIB_CRYPTO="libcrypto.1.1.dylib"
 
-cp "$PREBUILT_DIR/$LIB_SDL2" $APP_BUNDLE_FRAMEWORKS_DIR
-cp "$PREBUILT_DIR/$LIB_SDL2_IMAGE" $APP_BUNDLE_FRAMEWORKS_DIR
-cp "$PREBUILT_DIR/$LIB_SDL2_TTF" $APP_BUNDLE_FRAMEWORKS_DIR
-cp "$PREBUILT_DIR/$LIB_FREETYPE" $APP_BUNDLE_FRAMEWORKS_DIR
-cp "$PREBUILT_DIR/$LIB_PNG" $APP_BUNDLE_FRAMEWORKS_DIR
+cp "$SRC_DIR/$LIB_DIR/$LIB_SDL2" $APP_BUNDLE_FRAMEWORKS_DIR
+cp "$SRC_DIR/$LIB_DIR/$LIB_SDL2_IMAGE" $APP_BUNDLE_FRAMEWORKS_DIR
+cp "$SRC_DIR/$LIB_DIR/$LIB_SDL2_TTF" $APP_BUNDLE_FRAMEWORKS_DIR
+cp "$SRC_DIR/$LIB_DIR/$LIB_FREETYPE" $APP_BUNDLE_FRAMEWORKS_DIR
+cp "$SRC_DIR/$LIB_DIR/$LIB_PNG" $APP_BUNDLE_FRAMEWORKS_DIR
+cp "$SRC_DIR/$LIB_DIR/$LIB_OPENSSL" $APP_BUNDLE_FRAMEWORKS_DIR
+cp "$SRC_DIR/$LIB_DIR/$LIB_CRYPTO" $APP_BUNDLE_FRAMEWORKS_DIR
+
+# Change paths on libSDL
+
+install_name_tool -id @executable_path/../Frameworks/$LIB_SDL2 $APP_BUNDLE_FRAMEWORKS_DIR/$LIB_SDL2
+
+# Change paths on libSDL_image
+
+install_name_tool -id @executable_path/../Frameworks/$LIB_SDL2_IMAGE $APP_BUNDLE_FRAMEWORKS_DIR/$LIB_SDL2_IMAGE
+
+OLD_LIB_SDL2=`otool -LX  $APP_BUNDLE_FRAMEWORKS_DIR/$LIB_SDL2_IMAGE | grep $LIB_SDL2 | awk '{print $1}'`
+install_name_tool -change $OLD_LIB_SDL2 @executable_path/../Frameworks/$LIB_SDL2 $APP_BUNDLE_FRAMEWORKS_DIR/$LIB_SDL2_IMAGE
+
+# Change paths on libSDL_ttf
+
+install_name_tool -id @executable_path/../Frameworks/$LIB_SDL2_TTF $APP_BUNDLE_FRAMEWORKS_DIR/$LIB_SDL2_TTF
+
+OLD_LIB_SDL2=`otool -LX  $APP_BUNDLE_FRAMEWORKS_DIR/$LIB_SDL2_TTF | grep $LIB_SDL2 | awk '{print $1}'`
+OLD_LIB_FREETYPE=`otool -LX  $APP_BUNDLE_FRAMEWORKS_DIR/$LIB_SDL2_TTF | grep $LIB_FREETYPE | awk '{print $1}'`
+
+install_name_tool -change $OLD_LIB_SDL2 @executable_path/../Frameworks/$LIB_SDL2 $APP_BUNDLE_FRAMEWORKS_DIR/$LIB_SDL2_TTF
+install_name_tool -change $OLD_LIB_FREETYPE @executable_path/../Frameworks/$LIB_FREETYPE $APP_BUNDLE_FRAMEWORKS_DIR/$LIB_SDL2_TTF
+
+# Change paths on libpng
+
+install_name_tool -id @executable_path/../Frameworks/$LIB_PNG $APP_BUNDLE_FRAMEWORKS_DIR/$LIB_PNG
+
+# Change paths on Freetype
+
+install_name_tool -id @executable_path/../Frameworks/$LIB_FREETYPE $APP_BUNDLE_FRAMEWORKS_DIR/$LIB_FREETYPE
+
+OLD_LIB_PNG=`otool -LX $APP_BUNDLE_FRAMEWORKS_DIR/$LIB_FREETYPE | grep $LIB_PNG | awk '{print $1}'`
+install_name_tool -change $OLD_LIB_PNG @executable_path/../Frameworks/$LIB_PNG $APP_BUNDLE_FRAMEWORKS_DIR/$LIB_FREETYPE
+
+# Change paths on libOpenSSL
+
+install_name_tool -id @executable_path/../Frameworks/$LIB_OPENSSL $APP_BUNDLE_FRAMEWORKS_DIR/$LIB_OPENSSL
+
+OLD_LIB_CRYPTO=`otool -LX $APP_BUNDLE_FRAMEWORKS_DIR/$LIB_OPENSSL | grep $LIB_CRYPTO | awk '{print $1}'`
+install_name_tool -change $OLD_LIB_CRYPTO @executable_path/../Frameworks/$LIB_CRYPTO $APP_BUNDLE_FRAMEWORKS_DIR/$LIB_OPENSSL
+
+# Change paths on libCrypto
+
+install_name_tool -id @executable_path/../Frameworks/$LIB_CRYPTO $APP_BUNDLE_FRAMEWORKS_DIR/$LIB_CRYPTO
+
+# Change paths on main EXE
 
 OLD_LIB_SDL2=`otool -LX $EXE | grep $LIB_SDL2 | awk '{print $1}'`
 OLD_LIB_SDL2_IMAGE=`otool -LX $EXE | grep $LIB_SDL2_IMAGE | awk '{print $1}'`
 OLD_LIB_SDL2_TTF=`otool -LX $EXE | grep $LIB_SDL2_TTF | awk '{print $1}'`
+OLD_LIB_OPENSSL=`otool -LX $EXE | grep $LIB_OPENSSL | awk '{print $1}'`
+OLD_LIB_CRYPTO=`otool -LX $EXE | grep $LIB_CRYPTO | awk '{print $1}'`
 
 install_name_tool -change $OLD_LIB_SDL2 @executable_path/../Frameworks/$LIB_SDL2 $DST_EXE
 install_name_tool -change $OLD_LIB_SDL2_IMAGE @executable_path/../Frameworks/$LIB_SDL2_IMAGE $DST_EXE
 install_name_tool -change $OLD_LIB_SDL2_TTF @executable_path/../Frameworks/$LIB_SDL2_TTF $DST_EXE
+install_name_tool -change $OLD_LIB_OPENSSL @executable_path/../Frameworks/$LIB_OPENSSL $DST_EXE
+install_name_tool -change $OLD_LIB_CRYPTO @executable_path/../Frameworks/$LIB_CRYPTO $DST_EXE
 

--- a/macosx/bundle_macosx_app.sh
+++ b/macosx/bundle_macosx_app.sh
@@ -10,9 +10,13 @@ BUNDLE_NAME=
 APP_OWNER="com.evermizer"
 DEPLOYMENT_TARGET="10.12"
 BUILD_THIRD_PARTY=yes
+CLEAR_THIRD_PARTY=no
+
+BUILD_DIR="build"
+LIB_DIR="libs"
 
 function usage() {
-  echo "Usage: `basename $0` [--version=] [--bundle-name=] [--deployment-target=] [--do-not-build-thirdparty] binary"
+  echo "Usage: `basename $0` [--version=] [--bundle-name=] [--deployment-target=] [--do-not-build-thirdparty] [--clear-thirdparty-dirs] [binary]"
 }
 
 if test $# -eq 0; then
@@ -40,6 +44,9 @@ while test $# -gt 0; do
     --do-not-build-thirdparty)
       BUILD_THIRD_PARTY=no
       ;;
+    --clear-thirdparty-dirs)
+      CLEAR_THIRD_PARTY=yes
+      ;;
     *)
       EXE=$1
       if test $BUNDLE_NAME_SET = no ; then
@@ -50,9 +57,17 @@ while test $# -gt 0; do
   shift
 done
 
-APP_NAME=`basename $EXE`
-
 SRC_DIR=`dirname $0`
+
+if test $CLEAR_THIRD_PARTY = yes ; then
+  rm -fr $BUILD_DIR
+  rm -fr $LIB_DIR
+fi
+
+# Early out if executable is not specified.
+[ -z "$EXE" ] && exit 0
+
+APP_NAME=`basename $EXE`
 DST_DIR=`dirname $EXE`
 
 ROOT_DIR="$SRC_DIR/.."
@@ -108,8 +123,6 @@ cp -r $DOCS $APP_BUNDLE_MACOS_DIR
 # Build third party libraries and update dynamic paths
 # This won't work with libraries installed with brew.
 
-BUILD_DIR="build"
-LIB_DIR="libs"
 
 if test $BUILD_THIRD_PARTY = yes ; then
   sh $SRC_DIR/build_thirdparty.sh \

--- a/macosx/bundle_macosx_app.sh
+++ b/macosx/bundle_macosx_app.sh
@@ -112,10 +112,10 @@ BUILD_DIR="build"
 LIB_DIR="libs"
 
 if test $BUILD_THIRD_PARTY = yes ; then
-  sh $SRC_DIR/build_thirdparty \
+  sh $SRC_DIR/build_thirdparty.sh \
     --deployment-target=$DEPLOYMENT_TARGET \
-    --BUILD_DIR=$BUILD_DIR \
-    --LIB_DIR=$LIB_DIR
+    --build-dir=$BUILD_DIR \
+    --lib-dir=$LIB_DIR
 fi
 
 LIB_SDL2="libSDL2-2.0.0.dylib"


### PR DESCRIPTION
- Added script `build_thirdparty.sh` to clone and build third party libraries to be compatible with PopTracker bundle.
- Updated `bundle_macosx_app.sh` to adjust paths for new libraries.