### PR TITLE
Add plug-in license clarification

### DIFF
--- a/PLUGIN LICENSE ADDENDUM.md
+++ b/PLUGIN LICENSE ADDENDUM.md
@@ -1,0 +1,15 @@
+# Plug-In License Addendum
+
+We believe a user should be free to use any plug-in, regardless of license, as long as
+1. the plug-in specification / API is open and compatible to both PopTracker's license and the plug-in's license,
+   for example in a separate repository licensed under MIT,
+2. the plug-in does not embed any PopTracker code at compile-time,
+3. the plug-in is not required for PopTracker to function and
+4. the plug-in is installed separately.
+
+If this is found to be incompatible to GPLv3, this shall be an exception to PopTracker's license.
+
+To avoid edge cases, it is preferred to ship plug-ins as separate executables that communicate with PopTracker,
+with all communication defined in an external, license-compatible specification.
+
+Plug-ins that are fully license-compatible do not fall under those restrictions.

--- a/README.md
+++ b/README.md
@@ -91,3 +91,11 @@ No work has been done for other systems yet.
 * Major update (X.0.0) may break everything
 * Minor update (0.X.0) may change render output (i.e. window captures break)
 * Revisions (0.0.X) should only fix bugs and add non-breaking features
+
+## Plug-Ins
+
+Currently there is no plug-in interface.
+
+If you want to work towards implementing such a system, please check
+[PLUGIN LICENSE ADDENDUM.md](PLUGIN%20LICENSE%20ADDENDUM.md)
+for licensing considerations.


### PR DESCRIPTION
This adds a definition on how we want to handle licenses for plug-ins. Specifically the suggestion to support NDI is affected by this, because the NDI dll/sdk itself is not free software.  Since this might be a license exception, contributors to code of what is released together with this definition will have to approve to merge this.

Technically, C++ source code was only touched by myself and @pkprotoplasm as far as I can see.
However I would have a better feeling if @sbzappa, @Cyb3RGER, @ScipioWright and @lurch9229 could approve as well.
Since this will affect #52, approval by @coavins would also be appreciated.

Please comment and let me know if you have concerns, want to add something or outright want to block this. Otherwise please hit approve on the right.