### PR TITLE
fix manifest strict schema typo "mainfest"

### DIFF
--- a/schema/packs/strict/manifest.json
+++ b/schema/packs/strict/manifest.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://poptracker.github.io/schema/packs/strict/mainfest.json",
+    "$id": "https://poptracker.github.io/schema/packs/strict/manifest.json",
     "allOf": [
         {
             "$ref": "../manifest.json"


### PR DESCRIPTION
Fixes minor typo in manifest strict schema "mainfest" -> "manifest".