### PR TITLE
Change versions url for The Messenger Track Pack

### DIFF
--- a/community-packs.json
+++ b/community-packs.json
@@ -4,7 +4,7 @@
         "author": "alwaysintreble",
         "platform": "PC",
         "homepage": "https://github.com/alwaysintreble/TheMessengerTrackPack",
-        "versions_url": "https://raw.githubusercontent.com/alwaysintreble/TheMessengerTrackPack/master/versions.json",
+        "versions_url": "https://raw.githubusercontent.com/alwaysintreble/TheMessengerTrackPack/versions/versions.json",
         "icon_url": "https://raw.githubusercontent.com/alwaysintreble/TheMessengerTrackPack/master/TheMessengerTrackPack/images/SaveIcon.png",
         "description":  "Map Tracker for The Messenger Randomizer."
     }


### PR DESCRIPTION
Decided to move it to its own branch to stop muddying up my commit history 🤷