### PR TITLE
Fix description for optional access rules in json schema

### DIFF
--- a/schema/packs/locations.json
+++ b/schema/packs/locations.json
@@ -46,11 +46,11 @@
                             "type": "array",
                             "anyOf": [
                                 {
-                                    "description": "Access rules for the section. Section will be marked reachable (green) if all rules are matched. If rules in [] are matched, the section will be marked as reachable with glitches (yellow). If rules in {} are matched, the section will be marked as checkable (blue). Children will always inherit rules from parents. Each entry will be OR-ed together, comma sperated rules will be AND-ed.",
+                                    "description": "Access rules for the section. Section will be marked reachable (green) if all rules are matched. Rules inside [] are optional (i.e. glitches work around this rule; marked as yellow). If rules in {} are matched, the section will be marked as checkable (blue). Children will always inherit rules from parents. Each entry will be OR-ed together, comma sperated rules will be AND-ed.",
                                     "$ref": "#/$defs/rules_string"
                                 },
                                 {
-                                    "description": "Access rules for the section. Section will be marked reachable (green) if all rules are matched. If rules in [] are matched, the section will be marked as reachable with glitches (yellow). If rules in {} are matched, the section will be marked as checkable (blue). Children will always inherit rules from parents. 2-Dimensional array of rules, first dimenstion will be OR-ed together, second will be AND-ed.",
+                                    "description": "Access rules for the section. Section will be marked reachable (green) if all rules are matched. Rules inside [] are optional (i.e. glitches work around this rule; marked as yellow). If rules in {} are matched, the section will be marked as checkable (blue). Children will always inherit rules from parents. 2-Dimensional array of rules, first dimenstion will be OR-ed together, second will be AND-ed.",
                                     "$ref": "#/$defs/rules_array"
                                 }
                             ]

--- a/schema/packs/strict/locations.json
+++ b/schema/packs/strict/locations.json
@@ -45,11 +45,11 @@
                             "type": "array",
                             "anyOf": [
                                 {
-                                    "description": "Access rules for the section. Section will be marked reachable (green) if all rules are matched. If rules in [] are matched, the section will be marked as reachable with glitches (yellow). If rules in {} are matched, the section will be marked as checkable (blue). Children will always inherit rules from parents. Each entry will be OR-ed together, comma sperated rules will be AND-ed.",
+                                    "description": "Access rules for the section. Section will be marked reachable (green) if all rules are matched. Rules inside [] are optional (i.e. glitches work around this rule; marked as yellow). If rules in {} are matched, the section will be marked as checkable (blue). Children will always inherit rules from parents. Each entry will be OR-ed together, comma sperated rules will be AND-ed.",
                                     "$ref": "#/$defs/rules_string"
                                 },
                                 {
-                                    "description": "Access rules for the section. Section will be marked reachable (green) if all rules are matched. If rules in [] are matched, the section will be marked as reachable with glitches (yellow). If rules in {} are matched, the section will be marked as checkable (blue). Children will always inherit rules from parents. 2-Dimensional array of rules, first dimenstion will be OR-ed together, second will be AND-ed.",
+                                    "description": "Access rules for the section. Section will be marked reachable (green) if all rules are matched. Rules inside [] are optional (i.e. glitches work around this rule; marked as yellow). If rules in {} are matched, the section will be marked as checkable (blue). Children will always inherit rules from parents. 2-Dimensional array of rules, first dimenstion will be OR-ed together, second will be AND-ed.",
                                     "$ref": "#/$defs/rules_array"
                                 }
                             ]


### PR DESCRIPTION
Match wording of description for access rules in json schema with docs to accurately reflect usage