### PR TITLE
Fix memory watch crash

### DIFF
--- a/src/core/scripthost.cpp
+++ b/src/core/scripthost.cpp
@@ -410,6 +410,6 @@ void ScriptHost::runMemoryWatchCallbacks()
         if (_memoryWatches[i].name != name)
             i--; // watch at i changed (was removed)
         else if (res != false)
-            w.dirty = false; // watch returned non-false
+            _memoryWatches[i].dirty = false; // watch returned non-false
     }
 }

--- a/src/core/scripthost.cpp
+++ b/src/core/scripthost.cpp
@@ -66,7 +66,6 @@ ScriptHost::ScriptHost(Pack* pack, lua_State *L, Tracker *tracker)
         for (size_t i=0; i<_memoryWatches.size(); i++) {
             // NOTE: since watches can change in a callback, we use vector
             auto& w = _memoryWatches[i];
-            auto name = w.name;
             auto newData = _autoTracker->read((unsigned)w.addr, (unsigned)w.len);
             if (w.data != newData) {
                 DEBUG_printf("  %s changed\n", w.name.c_str());
@@ -80,9 +79,7 @@ ScriptHost::ScriptHost(Pack* pack, lua_State *L, Tracker *tracker)
                 w.data = newData;
                 w.dirty = true;
             }
-            if (_memoryWatches.size() <= i) break;
-            if (_memoryWatches[i].name != name) // current item not unchanged
-                i--;
+            // NOTE: we run the user callbacks in runMemoryWatchCallbacks
         }
     }};
     _autoTracker->onVariablesChanged += {this, [this](void*, const std::list<std::string>& vars) {


### PR DESCRIPTION
* don't use possibly-stale reference

    we use [] on vector because the callback list can change during execution,
    the .dirty=false would then use a stale reference, writing a 0 to random memory

* clean up remains of old code