### PR TITLE
Lua timeout hook

### DIFF
--- a/doc/PACKS.md
+++ b/doc/PACKS.md
@@ -132,6 +132,11 @@ a table representing an enum with the following constants: \
 `None`, `Partial`, `Inspeect`, `SequenceBreak`, `Normal`, `Cleared`
 
 
+### other globals
+
+* `DEBUG` set to true to get more error or debug output
+
+
 ### type LuaItem
 
 `use ImageRef = string`


### PR DESCRIPTION
Abort execution of Lua user function (`$`-Rule) after 100k instructions to avoid hanging on recursion and endless-loops.
This allows having recursion in logic that automatically aborts as unreachable - for performance reasons it would be better to detect or avoid such recursion in user code where possible.

Adds a global `DEBUG` to control how noisy error reporting is.