### PR TITLE
Add possibility for pure Lua logic

### DIFF
--- a/doc/PACKS.md
+++ b/doc/PACKS.md
@@ -329,6 +329,7 @@ Locations define drops on maps, rules to have them accessible as well as the loo
         {
             "name": "Area name",
             "short_name": "Area", // shorter version of name. currently unused
+            "access_resolver": "$func", // optional method to resolve access. overrides access_rules
             "access_rules": [
                 "<rule1>,<rule2>",
                 "<rule3>,<rule4>",
@@ -399,6 +400,11 @@ Locations define drops on maps, rules to have them accessible as well as the loo
 Each `map_location` is a square on the map and shows a popup with individual chests.
 
 **Rules:**
+If access_resolver if provided or inherited for a section and starts with `$`, access_rules are ignored and the
+provided global Lua function is called for each section instead of resolving access_rules. Useful for pure Lua logic.
+The Lua function has to return one of AccessibilityLevel values.
+If access_resolver is `""` (default), access_rules are resolved internally as described below.
+
 Rules starting with `$` will call the lua function with that name, `@<location>/<section>` will use the result of a different access rule, other rules will just look at items' `code` (runs ProviderCountForCode(rule)).
 
 For `$` rules, arguments can be supplied with `|`. `$test|a|b` will call `test("a","b")`.

--- a/schema/packs/locations.json
+++ b/schema/packs/locations.json
@@ -37,6 +37,10 @@
                             "description": "Short version of name. Currently unused.",
                             "type": "string"
                         },
+                        "access_resolver": {
+                            "description": "Optional method to resolve access. Use \"$func\" to call a Lua function with Section as argument that returns an AccessibilityLevel.",
+                            "type": "string"
+                        },
                         "access_rules": {
                             "example": [
                                 "rule1,rule2",
@@ -144,6 +148,10 @@
                 },
                 "short_name": {
                     "description": "Short version of name. Currently unused.",
+                    "type": "string"
+                },
+                "access_resolver": {
+                    "description": "Optional method to resolve access for each section. Use \"$func\" to call a Lua function with Section as argument that returns an AccessibilityLevel. This value is inherited by children, empty string resets to default behavior.",
                     "type": "string"
                 },
                 "access_rules": {

--- a/schema/packs/strict/locations.json
+++ b/schema/packs/strict/locations.json
@@ -36,6 +36,10 @@
                             "description": "Short version of name. Currently unused.",
                             "type": "string"
                         },
+                        "access_resolver": {
+                            "description": "Optional method to resolve access. Use \"$func\" to call a Lua function with Section as argument that returns an AccessibilityLevel.",
+                            "type": "string"
+                        },
                         "access_rules": {
                             "example": [
                                 "rule1,rule2",
@@ -126,6 +130,10 @@
                 },
                 "short_name": {
                     "description": "Short version of name. Currently unused.",
+                    "type": "string"
+                },
+                "access_resolver": {
+                    "description": "Optional method to resolve access for each section. Use \"$func\" to call a Lua function with Section as argument that returns an AccessibilityLevel. This value is inherited by children, empty string resets to default behavior.",
                     "type": "string"
                 },
                 "access_rules": {

--- a/src/core/location.h
+++ b/src/core/location.h
@@ -23,6 +23,7 @@ class LocationSection final : public LuaInterface<LocationSection> {
 public:
     static LocationSection FromJSON(nlohmann::json& j,
             const std::string parentId,
+            const std::string& parentAccessResolver="",
             const std::list< std::list<std::string> >& parentAccessRules={},
             const std::list< std::list<std::string> >& parentVisibilityRules={},
             const std::string& closedImg="", const std::string& openedImg="",
@@ -37,6 +38,7 @@ protected:
     int _itemCount=0;
     int _itemCleared=0;
     std::list<std::string> _hostedItems;
+    std::string _accessResolver;
     std::list< std::list<std::string> > _accessRules;
     std::list< std::list<std::string> > _visibilityRules;
     std::string _overlayBackground;
@@ -44,6 +46,7 @@ protected:
 public:
     // getters
     const std::string& getName() const { return _name; }
+    const std::string& getAccessResolver() const { return _accessResolver; }
     const std::list< std::list<std::string> > getAccessRules() const { return _accessRules; }
     const std::list< std::list<std::string> > getVisibilityRules() const { return _visibilityRules; }
     int getItemCount() const { return _itemCount; }
@@ -95,6 +98,7 @@ public:
 
     static std::list<Location> FromJSON(nlohmann::json& j,
         const std::list<Location>& parentLookup,
+        const std::string& parentAccessResolver="",
         const std::list< std::list<std::string> >& parentAccessRules={},
         const std::list< std::list<std::string> >& parentVisibilityRules={},
         const std::string& parentName="", const std::string& closedImg="",
@@ -106,6 +110,7 @@ protected:
     std::string _id;
     std::list<MapLocation> _mapLocations;
     std::list<LocationSection> _sections;
+    std::string _accessResolver; // this is only used if referenced through @-RUles
     std::list< std::list<std::string> > _accessRules; // this is only used if referenced through @-Rules
     std::list< std::list<std::string> > _visibilityRules;
 public:
@@ -115,6 +120,7 @@ public:
     const std::list<MapLocation>& getMapLocations() const { return _mapLocations; }
     std::list<LocationSection>& getSections() { return _sections; }
     const std::list<LocationSection>& getSections() const { return _sections; }
+    const std::string& getAccessResolver() const { return _accessResolver; }
     std::list< std::list<std::string> >& getAccessRules() { return _accessRules; }
     const std::list< std::list<std::string> >& getAccessRules() const { return _accessRules; }
     std::list< std::list<std::string> >& getVisibilityRules() { return _visibilityRules; }


### PR DESCRIPTION
- `access_resolver` in json makes PopTracker call Lua functions for each Section to provide accessibility

--

- [x] Documentation
- [x] JSON Schema
- [x] Read/inherit values from JSON
- [ ] Actually call Lua function and override accessibility behaviour