### PR TITLE
Add LuaLS definition file and update example and docs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,7 @@ on:
       - '!**.md'
       - '!doc/**'
       - '!schema/**'
+      - '!api/lua/definition/**'
       - '!.github/workflows/**'
       - '.github/workflows/test.yaml'
   pull_request:
@@ -19,6 +20,7 @@ on:
       - '!**.md'
       - '!doc/**'
       - '!schema/**'
+      - '!api/lua/definition/**'
       - '!.github/workflows/**'
       - '.github/workflows/test.yaml'
 

--- a/Makefile
+++ b/Makefile
@@ -262,6 +262,7 @@ $(WIN32_ZIP) $(WIN64_ZIP):
 	$(eval TMP_DIR = $(DIST_DIR)/.tmp-$(TGT))
 	rm -rf $(TMP_DIR)
 	mkdir -p $(TMP_DIR)/poptracker/packs
+	cp -r api $(TMP_DIR)/poptracker/
 	cp -r assets $(TMP_DIR)/poptracker/
 	cp LICENSE README.md CHANGELOG.md CREDITS.md $(TMP_DIR)/poptracker/
 	cp $(dir $<)*.exe $(TMP_DIR)/poptracker/
@@ -293,6 +294,7 @@ $(NIX_XZ): $(NIX_EXE) | $(DIST_DIR)
 	$(eval TMP_DIR = $(DIST_DIR)/.tmp-nix)
 	rm -rf $(TMP_DIR)
 	mkdir -p $(TMP_DIR)/poptracker/packs
+	cp -r api $(TMP_DIR)/poptracker/
 	cp -r assets $(TMP_DIR)/poptracker/
 	cp LICENSE README.md CHANGELOG.md CREDITS.md $(TMP_DIR)/poptracker/
 	cp $(NIX_EXE) $(TMP_DIR)/poptracker/

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,8 @@
+# API
+
+These files are definitions of APIs.
+
+[lua](lua) contains a definition file for the
+[PopTracker Lua API](https://github.com/black-sliver/PopTracker/blob/master/doc/PACKS.md#lua-interface).
+
+See [/doc/](https://github.com/black-sliver/PopTracker/tree/master/doc) for more info.

--- a/api/lua/definition/poptracker.lua
+++ b/api/lua/definition/poptracker.lua
@@ -21,11 +21,12 @@ PopVersion = "0.25.7"
 ---@type boolean
 DEBUG = false
 
----If defined in global scope, called when a game is connected (currently memory interfaces only)
----@type function():nil
+---If defined in global scope, called when a game is connected (currently memory interfaces only).
+---@type fun():nil
 autotracker_started = nil
 
----If defined in global scope, called when auto-tracking is disabled by the user (currently memory interfaces only)
+---If defined in global scope, called when auto-tracking is disabled by the user (currently memory interfaces only).
+---@type fun():nil
 autotracker_stopped = nil
 
 
@@ -38,43 +39,43 @@ Tracker = {}
 Tracker.ActiveVariantUID = ""
 
 ---load items from json
----@param jsonFIlename string
+---@param jsonFilename string file to load, relative to variant folder or root of the pack (will try both)
 ---@return boolean true on success
-function Tracker:AddItems(jsonFIlename) end
+function Tracker:AddItems(jsonFilename) end
 
 ---load maps from json
----@param jsonFilename string
+---@param jsonFilename string file to load, relative to variant folder or root of the pack (will try both)
 ---@return boolean true on success
 function Tracker:AddMaps(jsonFilename) end
 
 ---load locations from json
----@param jsonFilename string
+---@param jsonFilename string file to load, relative to variant folder or root of the pack (will try both)
 ---@return boolean true on success
 function Tracker:AddLocations(jsonFilename) end
 
 ---load layouts from json
----@param jsonFilename string
+---@param jsonFilename string file to load, relative to variant folder or root of the pack (will try both)
 ---@return boolean true on success
 function Tracker:AddLayouts(jsonFilename) end
 
----Returns number of items that provide the code (sum of count for consumables).
----@param code string
----@return integer
+---get provided count for an (item) code
+---@param code string the (item) code to look up
+---@return integer count of items providing the code or the sum of count for consumables
 function Tracker:ProviderCountForCode(code) end
 
----Returns item for `code` or location section for `@location/section`
----@param code string
----@return AnyObject?
+---get item for `code`, location for `@location` or location section for `@location/section`
+---@param code string the code to look up
+---@return AnyObject? object that matches the code
 function Tracker:FindObjectForCode(code) end
 
----Sends a hint to the UI, see https://github.com/black-sliver/PopTracker/blob/master/doc/PACKS.md#ui-hints
----Only available in PopTracker, since 0.11.0
+---Sends a hint to the UI, see https://github.com/black-sliver/PopTracker/blob/master/doc/PACKS.md#ui-hints .
+---Only available in PopTracker, since 0.11.0.
 ---@param name string
 ---@param value string
 ---@return nil
 function Tracker:UiHint(name, value) end
 
----can be set to true from Lua to pause running logic rules.
+---pause evaluating logic rules when set to true
 ---@type boolean
 Tracker.BulkUpdate = false
 
@@ -89,18 +90,18 @@ ScriptHost = {}
 ---* require can be used instead since 0.25.6 (0.21.0 in some cases)
 ---    * `require "foo.baz"` will try `/scripts/foo/baz.lua`, `/scripts/foo/baz/init.lua`,
 ---    `/foo/baz.lua` and `/foo/baz/init.lua`
----    * LoadScript needs absolute path instead
+---    * LoadScript needs an "absolute" path (including `scripts/`) instead
 ---    * LoadScript needs to use globals, require can return for `local x = require "foo"`
----* require is recommended if backwards compatibility is not required.
----@param luaFilename string
+---* require is recommended if backwards compatibility is not required
+---@param luaFilename string file to run, relative to variant folder or root of the pack (will try both)
 ---@return boolean true on success
 function ScriptHost:LoadScript(luaFilename) end
 
 ---add a memory watch for auto-tracking, see [AUTOTRACKING.md](https://github.com/black-sliver/PopTracker/blob/master/doc/AUTOTRACKING.md)
----@param name string
----@param addr integer
----@param len integer
----@param callback function(segment:Segment):nil
+---@param name string identifier/name of this watch
+---@param addr integer start address of memory block to watch
+---@param len integer length of memory block to watch in bytes
+---@param callback fun(segment:Segment):nil called when watched memory changes
 ---@param interval integer? milliseconds
 ---@return string reference for RemoveMemoryWatch
 function ScriptHost:AddMemoryWatch(name, addr, len, callback, interval) end
@@ -112,10 +113,10 @@ function ScriptHost:RemoveMemoryWatch(name) end
 
 ---callback(code) will be called whenever an item changed state that canProvide(code).
 ---Only available in PopTracker, since 0.11.0,
----@param name string
+---@param name string identifier/name of this watch
 ---@param code string Code to watch for. Use `"*"` for *all* codes since 0.25.5.
----@param callback function(code:string):nil
----@return string reference for RemoveWatchForCode since 0.18.2.
+---@param callback fun(code:string):nil called when warched (item) code changes
+---@return string reference for RemoveWatchForCode since 0.18.2
 function ScriptHost:AddWatchForCode(name, code, callback) end
 
 ---remove watch for code by name/reference, available since 0.18.2
@@ -123,22 +124,22 @@ function ScriptHost:AddWatchForCode(name, code, callback) end
 ---@return boolean true on success
 function ScriptHost:RemoveWatchForCode(name) end
 
----callback(store, {var_name, ...}) will be called whenever a remote variable changes.
+---callback(store, {variableName, ...}) will be called whenever a remote variable changes.
 ---See [AUTOTRACKING.md](https://github.com/black-sliver/PopTracker/blob/master/doc/AUTOTRACKING.md#variable-interface-uat)
 -- and [UAT REDME.md](https://github.com/black-sliver/UAT/blob/master/README.md) for more info.
----@param name string
+---@param name string identifier/name of this watch
 ---@param variables string[] array of variable names
----@param callback function(store:VariableStore, changed_keys_array:table):nil
+---@param callback fun(store:VariableStore, changedKeysArray:table):nil called when any watched variable changes
 ---@param interval integer? optional, currently unused
----@return string reference for RemoveVariableWatch since 0.18.2.
+---@return string reference for RemoveVariableWatch since 0.18.2
 function ScriptHost:AddVariableWatch(name, variables, callback, interval) end
 
 ---remove variable watch by name/reference
----@param name any
+---@param name string
 ---@returns boolean true on success
 function ScriptHost:RemoveVariableWatch(name) end
 
----Create a new LuaItem
+---create a new LuaItem
 ---@return LuaItem 
 function ScriptHost:CreateLuaItem() end
 
@@ -191,7 +192,7 @@ function AutoTracker:ReadVariable(variableName) end
 ---| 0 # Disabled
 ---| 1 # Disconnected
 ---| 2 # Socket Connected (not ready)
----| 3 # Game/Consolve connected (ready)
+---| 3 # Game/Console connected (ready)
 
 ---get an integer corresponding to the current state of an auto-tracking backend.
 -- Available since 0.20.2.
@@ -245,7 +246,7 @@ function VariableStore:ReadVariable(variableName) end
 ---@class Archipelago
 Archipelago = {}
 
----The slot number of the connected player or -1 if not connected
+---The slot number of the connected player or -1 if not connected.
 ---@type integer
 Archipelago.PlayerNumber = -1
 
@@ -265,81 +266,81 @@ Archipelago.CheckedLocations = {}
 Archipelago.MissingLocations = {}
 
 ---Add callback to be called when connecting to a (new) server and state should be cleared.
----@param name string Identifier/name of this handler (for debugging)
----@param callback function(slotData:{ [string]: any }):nil
+---@param name string identifier/name of this handler (for debugging)
+---@param callback fun(slotData:{ [string]: any }):nil
 ---@return boolean true on success
 function Archipelago:AddClearHandler(name, callback) end
 
 ---Add callback to be called when called when an item is received.
 ---(player_number not in callback before 0.20.2)
----@param name string Identifier/name of this handler (for debugging)
----@param callback function(index:integer, itemID:integer, itemName:string, playerNumber:integer):nil
+---@param name string identifier/name of this handler (for debugging)
+---@param callback fun(index:integer, itemID:integer, itemName:string, playerNumber:integer):nil
 ---@return boolean true on success
 function Archipelago:AddItemHandler(name, callback) end
 
 ---Add callback to be called when a location was checked.
----@param name string Identifier/name of this handler (for debugging)
----@param callback function(locationID:integer, locationName:string):nil
+---@param name string identifier/name of this handler (for debugging)
+---@param callback fun(locationID:integer, locationName:string):nil
 ---@return boolean true on success
 function Archipelago:AddLocationHandler(name, callback) end
 
 ---Add callback to be called when a location was scouted.
----@param name string Identifier/name of this handler (for debugging)
----@param callback function(locationID:integer, locationName:string, itemID:integer, itemName:string, itemPlayer:integer):nil
+---@param name string identifier/name of this handler (for debugging)
+---@param callback fun(locationID:integer, locationName:string, itemID:integer, itemName:string, itemPlayer:integer):nil
 ---@return boolean true on success
 function Archipelago:AddScoutHandler(name, callback) end
 
 ---Add callback to be called when the server sends a bounce.
----@param name string Identifier/name of this handler (for debugging)
----@param callback function(message:{ [string]: any }):nil
+---@param name string identifier/name of this handler (for debugging)
+---@param callback fun(message:{ [string]: any }):nil called when receiving a bounce
 ---@return boolean true on success
 function Archipelago:AddBouncedHandler(name, callback) end
 
 ---Add callback to be called when the server replies to Get.
----@param name string Identifier/name of this handler (for debugging)
----@param callback function(key:string, value:any):nil
+---@param name string identifier/name of this handler (for debugging)
+---@param callback fun(key:string, value:any):nil
 ---@return boolean true on success
 function Archipelago:AddRetrievedHandler(name, callback) end
 
 ---Add callback to be called when a watched data storage value is changed.
----@param name string Identifier/name of this handler (for debugging)
----@param callback function(key:string, value:any, oldValue:any):nil
+---@param name string identifier/name of this handler (for debugging)
+---@param callback fun(key:string, value:any, oldValue:any):nil
 ---@return boolean true on success
 function Archipelago:AddSetReplyHandler(name, callback) end
 
 ---Ask the server for values from data storage, run this from a ClearHandler, keys is an array of strings.
----@param keys string[] Keys to get
+---@param keys string[] keys to get
 ---@return boolean true on success
 function Archipelago:Get(keys) end
 
 ---Ask the server to notify when a data storage value is changed.
 ---Run this from a ClearHandler, keys is an array of strings.
----@param keys string[] Keys to watch
+---@param keys string[] keys to watch
 ---@return boolean true on success
 function Archipelago:SetNotify(keys) end
 
 
 ---- ImageRef ----
 
----Reference to a single image (currently a string)
+---reference to a single image (currently a string)
 ---@class ImageRef
 ImageRef = {}
 
 
 ---- ImageReference ----
 
----Utility to create `ImageRef`s
+---utility to create `ImageRef`s
 ---@class ImageReference
 ImageReference = {}
 
----Get an image reference from filename.
+---Create an image reference from filename.
 ---Note: currently path resultion happens when the ImageRef is being used, so there is no way to detect errors.
 ---@param filename string
 ---@return ImageRef reference to the image for filename
 function ImageReference:FromPackRelativePath(filename) end
 
----Get an image reference with mods applied
----@param original ImageRef
+---Create an image reference with mods applied on top of another image reference.
+---@param original ImageRef the base image
 ---@param mod string Mod(s) to apply. Separate with ',' for multiple.
 ---@return ImageRef reference to the new image
 function ImageReference:FromImageReference(original, mod) end
@@ -385,41 +386,41 @@ LuaItem.Type = "custom"
 
 ---Called to match item to code (to place it in layouts).
 ---Note: LuaItems have to be created before the corresponding layout is loaded.
----@type function(self:LuaItem, code:string):boolean
+---@type fun(self:LuaItem, code:string):boolean
 LuaItem.CanProvideCodeFunc = nil
 
 ---Called to check if item provides code for access rules (ProviderCountForCode).
----@type function(self:LuaItem, code:string):boolean
+---@type fun(self:LuaItem, code:string):boolean
 LuaItem.ProvidesCodeFunc = nil
 
 ---Called to change item's stage to provide code (not in use yet).
----@type function(self:LuaItem, code:string)
+---@type fun(self:LuaItem, code:string)
 LuaItem.AdvanceToCodeFunc = nil
 
 ---Called when item is left-clicked.
----@type function(self:LuaItem):nil
+---@type fun(self:LuaItem):nil
 LuaItem.OnLeftClickFunc = nil
 
 ---Called when item is right-clicked.
----@type function(self:LuaItem):nil
+---@type fun(self:LuaItem):nil
 LuaItem.OnRightClickFunc = nil
 
 ---Called when item is middle-clicked.
 ---PopTracker, since 0.25.8.
----@type function(self:LuaItem):nil
+---@type fun(self:LuaItem):nil
 LuaItem.OnMiddleClickFunc = nil
 
 ---Called when saving. Should return a Lua object that works in `LoadFunc`.
----@type function(self:LuaItem):any
+---@type fun(self:LuaItem):any
 LuaItem.SaveFunc = nil
 
 ---Callend when loading, data as returned by `SaveFunc`.
----@type function(self:LuaItem, data:any):nil
+---@type fun(self:LuaItem, data:any):nil
 LuaItem.LoadFunc = nil
 
 ---Called when :Set was called and the value changed.
 ---Can be used to update `.Icon`, etc. from `.ItemState` or `:Get()`.
----@type function(self:LuaItem, key:string, value:any):nil
+---@type fun(self:LuaItem, key:string, value:any):nil
 LuaItem.PropertyChangedFunc = nil
 
 ---Write to property store. If the value changed, this will call `.PropertyChangedFunc`.
@@ -435,7 +436,7 @@ function LuaItem:Set(key, value) end
 function LuaItem:Get(key) end
 
 ---Set item overlay text (like count, but also for non-consumables).
----(Only available in PopTracker)
+---Only available in PopTracker.
 ---@param text string
 function LuaItem:SetOverlay(text) end
 
@@ -458,7 +459,7 @@ JsonItem = {}
 ---Get or set the item's image. Use `ImageReference:FromPackRelativePath` to create an `ImageRef`.
 ---For performance reasons, using a staged item is recommended.
 ---Currently only works for items of type toggle and static.
--- Available since 0.26.0
+-- Available since 0.26.0.
 ---@type ImageRef?
 JsonItem.Icon = nil
 
@@ -500,7 +501,7 @@ JsonItem.Owner = {}
 JsonItem.Type = ""
 
 ---Set item overlay text (like count, but also for non-consumables).
----(Only available in PopTracker)
+---Only available in PopTracker.
 ---@param text string
 function JsonItem:SetOverlay(text) end
 

--- a/api/lua/definition/poptracker.lua
+++ b/api/lua/definition/poptracker.lua
@@ -1,0 +1,548 @@
+---@meta
+
+--
+-- PopTracker API definition file.
+-- Do NOT load this into your pack.
+-- Read docs/PACKS.md#lua-interface for instructions.
+--
+
+---- Helpers ----
+
+---@alias AnyObject JsonItem | LuaItem | LocationSection | Location
+
+
+---- Globals ----
+
+---Currently running PopTracker version as string.
+---@type string
+PopVersion = "0.25.7"
+
+---Set to true to get more error or debug output.
+---@type boolean
+DEBUG = false
+
+---If defined in global scope, called when a game is connected (currently memory interfaces only)
+---@type function():nil
+autotracker_started = nil
+
+---If defined in global scope, called when auto-tracking is disabled by the user (currently memory interfaces only)
+autotracker_stopped = nil
+
+
+---- Tracker ----
+
+---@class Tracker
+Tracker = {}
+
+---@type string
+Tracker.ActiveVariantUID = ""
+
+---load items from json
+---@param jsonFIlename string
+---@return boolean true on success
+function Tracker:AddItems(jsonFIlename) end
+
+---load maps from json
+---@param jsonFilename string
+---@return boolean true on success
+function Tracker:AddMaps(jsonFilename) end
+
+---load locations from json
+---@param jsonFilename string
+---@return boolean true on success
+function Tracker:AddLocations(jsonFilename) end
+
+---load layouts from json
+---@param jsonFilename string
+---@return boolean true on success
+function Tracker:AddLayouts(jsonFilename) end
+
+---Returns number of items that provide the code (sum of count for consumables).
+---@param code string
+---@return integer
+function Tracker:ProviderCountForCode(code) end
+
+---Returns item for `code` or location section for `@location/section`
+---@param code string
+---@return AnyObject?
+function Tracker:FindObjectForCode(code) end
+
+---Sends a hint to the UI, see https://github.com/black-sliver/PopTracker/blob/master/doc/PACKS.md#ui-hints
+---Only available in PopTracker, since 0.11.0
+---@param name string
+---@param value string
+---@return nil
+function Tracker:UiHint(name, value) end
+
+---can be set to true from Lua to pause running logic rules.
+---@type boolean
+Tracker.BulkUpdate = false
+
+
+---- ScriptHost ----
+
+---@class ScriptHost
+ScriptHost = {}
+
+---Load and execute a Lua script from absolute filename inside pack.
+---* sets `...` variable to mod name (for relative require) since 0.25.6
+---* require can be used instead since 0.25.6 (0.21.0 in some cases)
+---    * `require "foo.baz"` will try `/scripts/foo/baz.lua`, `/scripts/foo/baz/init.lua`,
+---    `/foo/baz.lua` and `/foo/baz/init.lua`
+---    * LoadScript needs absolute path instead
+---    * LoadScript needs to use globals, require can return for `local x = require "foo"`
+---* require is recommended if backwards compatibility is not required.
+---@param luaFilename string
+---@return boolean true on success
+function ScriptHost:LoadScript(luaFilename) end
+
+---add a memory watch for auto-tracking, see [AUTOTRACKING.md](https://github.com/black-sliver/PopTracker/blob/master/doc/AUTOTRACKING.md)
+---@param name string
+---@param addr integer
+---@param len integer
+---@param callback function(segment:Segment):nil
+---@param interval integer? milliseconds
+---@return string reference for RemoveMemoryWatch
+function ScriptHost:AddMemoryWatch(name, addr, len, callback, interval) end
+
+---remove memory watch by name/reference, available since 0.11.0
+---@param name string
+---@return boolean true on success
+function ScriptHost:RemoveMemoryWatch(name) end
+
+---callback(code) will be called whenever an item changed state that canProvide(code).
+---Only available in PopTracker, since 0.11.0,
+---@param name string
+---@param code string Code to watch for. Use `"*"` for *all* codes since 0.25.5.
+---@param callback function(code:string):nil
+---@return string reference for RemoveWatchForCode since 0.18.2.
+function ScriptHost:AddWatchForCode(name, code, callback) end
+
+---remove watch for code by name/reference, available since 0.18.2
+---@param name string
+---@return boolean true on success
+function ScriptHost:RemoveWatchForCode(name) end
+
+---callback(store, {var_name, ...}) will be called whenever a remote variable changes.
+---See [AUTOTRACKING.md](https://github.com/black-sliver/PopTracker/blob/master/doc/AUTOTRACKING.md#variable-interface-uat)
+-- and [UAT REDME.md](https://github.com/black-sliver/UAT/blob/master/README.md) for more info.
+---@param name string
+---@param variables string[] array of variable names
+---@param callback function(store:VariableStore, changed_keys_array:table):nil
+---@param interval integer? optional, currently unused
+---@return string reference for RemoveVariableWatch since 0.18.2.
+function ScriptHost:AddVariableWatch(name, variables, callback, interval) end
+
+---remove variable watch by name/reference
+---@param name any
+---@returns boolean true on success
+function ScriptHost:RemoveVariableWatch(name) end
+
+---Create a new LuaItem
+---@return LuaItem 
+function ScriptHost:CreateLuaItem() end
+
+
+---- AutoTracker ----
+
+---@class AutoTracker
+AutoTracker = {}
+
+---read 8bit unsigned integer, may return 0 if not yet cached
+---@param baseAddr integer address to read
+---@param offset integer? added to baseAddr to get the final address
+---@return integer value at address
+function AutoTracker:ReadU8(baseAddr, offset) end
+
+---read 16bit unsigned integer, may return 0 if not yet cached
+---@param baseAddr integer address to read
+---@param offset integer? added to baseAddr to get the final address
+---@return integer value at address
+function AutoTracker:ReadU16(baseAddr, offset) end
+
+---read 24bit unsigned integer, may return 0 if not yet cached
+---@param baseAddr integer address to read
+---@param offset integer? added to baseAddr to get the final address
+---@return integer value at address
+function AutoTracker:ReadU24(baseAddr, offset) end
+
+---read 32bit unsigned integer, may return 0 if not yet cached
+---@param baseAddr integer address to read
+---@param offset integer? added to baseAddr to get the final address
+---@return integer value at address
+function AutoTracker:ReadU32(baseAddr, offset) end
+
+---currently an empty table for compatibility
+---@type table
+AutoTracker.SelectedConnectorType = {}
+
+---Returns what the remote (UAT) sent for the variableName.<br/>
+---**This is deprecated** and it's recommended to use `store:ReadVariable` in a callback instead.
+---Use `if ScriptHost.AddVariableWatch then` to detect if UAT is available in this version of PopTracker.
+---@deprecated
+---@param variableName string
+---@return any value of variable or nil
+function AutoTracker:ReadVariable(variableName) end
+
+---@alias AutoTrackingBackendName "SNES" | "UAT" | "AP"
+
+---@alias AutoTrackingState
+---| -1 # Unavailable
+---| 0 # Disabled
+---| 1 # Disconnected
+---| 2 # Socket Connected (not ready)
+---| 3 # Game/Consolve connected (ready)
+
+---get an integer corresponding to the current state of an auto-tracking backend.
+-- Available since 0.20.2.
+---@param backendName AutoTrackingBackendName name of the backend (case sensitive)
+---@return AutoTrackingState state of the backend
+function AutoTracker:GetConnectionState(backendName) end
+
+
+---- Segment ---
+
+---NOTE: the segment API is provided by `AutoTracker`, but this is not backwards compatible.
+-- `ReadU8` should only be used on global AutoTracker and `ReadUInt8` on segment from watch callback.
+---@class Segment
+Segment = {}
+
+---read 8bit unsigned integer, may return 0 if used on AutoTracker instead of Segment
+---@param address integer (absolute) address to read
+---@return integer value at address
+function Segment:ReadUInt8(address) end
+
+---read 16bit unsigned integer, may return 0 if used on AutoTracker instead of Segment
+---@param address integer (absolute) address to read
+---@return integer value at address
+function Segment:ReadUInt16(address) end
+
+---read 24bit unsigned integer, may return 0 if used on AutoTracker instead of Segment
+---@param address integer (absolute) address to read
+---@return integer value at address
+function Segment:ReadUInt24(address) end
+
+---read 32bit unsigned integer, may return 0 if used on AutoTracker instead of Segment
+---@param address integer (absolute) address to read
+---@return integer value at address
+function Segment:ReadUInt32(address) end
+
+
+---- VariableStore ----
+
+---NOTE: the store API is provided by `AutoTracker`, but this may change in the future.
+---@class VariableStore
+VariableStore = {}
+
+---Returns what the remote (UAT) sent for the variableName.
+---@param variableName string
+---@return any value of variable or nil
+function VariableStore:ReadVariable(variableName) end
+
+
+---- Archipelago ----
+
+---@class Archipelago
+Archipelago = {}
+
+---The slot number of the connected player or -1 if not connected
+---@type integer
+Archipelago.PlayerNumber = -1
+
+---The team number of the connected player, -1 if not connected or `nil` if unsupported.
+---Supported since 0.25.2.
+---@type integer
+Archipelago.TeamNumber = -1
+
+---Array of already checked location IDs or `nil` if unsupported.
+---Supported since 0.25.2.
+---@type integer[]
+Archipelago.CheckedLocations = {}
+
+---Array of unchecked/missing location IDs or `nil` if unsupported.
+---Supported since 0.25.2.
+---@type integer[]
+Archipelago.MissingLocations = {}
+
+---Add callback to be called when connecting to a (new) server and state should be cleared.
+---@param name string Identifier/name of this handler (for debugging)
+---@param callback function(slotData:{ [string]: any }):nil
+---@return boolean true on success
+function Archipelago:AddClearHandler(name, callback) end
+
+---Add callback to be called when called when an item is received.
+---(player_number not in callback before 0.20.2)
+---@param name string Identifier/name of this handler (for debugging)
+---@param callback function(index:integer, itemID:integer, itemName:string, playerNumber:integer):nil
+---@return boolean true on success
+function Archipelago:AddItemHandler(name, callback) end
+
+---Add callback to be called when a location was checked.
+---@param name string Identifier/name of this handler (for debugging)
+---@param callback function(locationID:integer, locationName:string):nil
+---@return boolean true on success
+function Archipelago:AddLocationHandler(name, callback) end
+
+---Add callback to be called when a location was scouted.
+---@param name string Identifier/name of this handler (for debugging)
+---@param callback function(locationID:integer, locationName:string, itemID:integer, itemName:string, itemPlayer:integer):nil
+---@return boolean true on success
+function Archipelago:AddScoutHandler(name, callback) end
+
+---Add callback to be called when the server sends a bounce.
+---@param name string Identifier/name of this handler (for debugging)
+---@param callback function(message:{ [string]: any }):nil
+---@return boolean true on success
+function Archipelago:AddBouncedHandler(name, callback) end
+
+---Add callback to be called when the server replies to Get.
+---@param name string Identifier/name of this handler (for debugging)
+---@param callback function(key:string, value:any):nil
+---@return boolean true on success
+function Archipelago:AddRetrievedHandler(name, callback) end
+
+---Add callback to be called when a watched data storage value is changed.
+---@param name string Identifier/name of this handler (for debugging)
+---@param callback function(key:string, value:any, oldValue:any):nil
+---@return boolean true on success
+function Archipelago:AddSetReplyHandler(name, callback) end
+
+---Ask the server for values from data storage, run this from a ClearHandler, keys is an array of strings.
+---@param keys string[] Keys to get
+---@return boolean true on success
+function Archipelago:Get(keys) end
+
+---Ask the server to notify when a data storage value is changed.
+---Run this from a ClearHandler, keys is an array of strings.
+---@param keys string[] Keys to watch
+---@return boolean true on success
+function Archipelago:SetNotify(keys) end
+
+
+---- ImageRef ----
+
+---Reference to a single image (currently a string)
+---@class ImageRef
+ImageRef = {}
+
+
+---- ImageReference ----
+
+---Utility to create `ImageRef`s
+---@class ImageReference
+ImageReference = {}
+
+---Get an image reference from filename.
+---Note: currently path resultion happens when the ImageRef is being used, so there is no way to detect errors.
+---@param filename string
+---@return ImageRef reference to the image for filename
+function ImageReference:FromPackRelativePath(filename) end
+
+---Get an image reference with mods applied
+---@param original ImageRef
+---@param mod string Mod(s) to apply. Separate with ',' for multiple.
+---@return ImageRef reference to the new image
+function ImageReference:FromImageReference(original, mod) end
+
+
+---- AccessibilityLevel (enum) ----
+
+---@enum accessibilityLevel
+AccessibilityLevel = {
+    None = 0,
+    Partial = 1,
+    Inspect = 3,
+    SequenceBreak = 5,
+    Normal = 6,
+    Cleared = 7,
+}
+
+
+---- LuaItem ----
+
+---@class LuaItem
+LuaItem = {}
+
+---Name of the item, displayed in tooltip.
+---@type string
+LuaItem.Name = ""
+
+---Get or set the item's image. Use `ImageReference:FromPackRelativePath` to create an `ImageRef`.
+---@type ImageRef?
+LuaItem.Icon = nil
+
+---Optional container to store item's state. Keys have to be string for `:Get` and `:Set` to work.
+---@type table?
+LuaItem.ItemState = nil
+
+---At the moment (since 0.18.2) an empty table for compatibility reasons.
+---@type table
+LuaItem.Owner = {}
+
+---Type of the item (since 0.23.0). Always "custom" for LuaItem.
+---@type string
+LuaItem.Type = "custom"
+
+---Called to match item to code (to place it in layouts).
+---Note: LuaItems have to be created before the corresponding layout is loaded.
+---@type function(self:LuaItem, code:string):boolean
+LuaItem.CanProvideCodeFunc = nil
+
+---Called to check if item provides code for access rules (ProviderCountForCode).
+---@type function(self:LuaItem, code:string):boolean
+LuaItem.ProvidesCodeFunc = nil
+
+---Called to change item's stage to provide code (not in use yet).
+---@type function(self:LuaItem, code:string)
+LuaItem.AdvanceToCodeFunc = nil
+
+---Called when item is left-clicked.
+---@type function(self:LuaItem):nil
+LuaItem.OnLeftClickFunc = nil
+
+---Called when item is right-clicked.
+---@type function(self:LuaItem):nil
+LuaItem.OnRightClickFunc = nil
+
+---Called when item is middle-clicked.
+---PopTracker, since 0.25.8.
+---@type function(self:LuaItem):nil
+LuaItem.OnMiddleClickFunc = nil
+
+---Called when saving. Should return a Lua object that works in `LoadFunc`.
+---@type function(self:LuaItem):any
+LuaItem.SaveFunc = nil
+
+---Callend when loading, data as returned by `SaveFunc`.
+---@type function(self:LuaItem, data:any):nil
+LuaItem.LoadFunc = nil
+
+---Called when :Set was called and the value changed.
+---Can be used to update `.Icon`, etc. from `.ItemState` or `:Get()`.
+---@type function(self:LuaItem, key:string, value:any):nil
+LuaItem.PropertyChangedFunc = nil
+
+---Write to property store. If the value changed, this will call `.PropertyChangedFunc`.
+---NOTE: if `.ItemState` is set, that is the property store, otherwise there is an automatic one.
+---@param key string
+---@param value any
+function LuaItem:Set(key, value) end
+
+---Read from property store.
+---NOTE: if `.ItemState` is set, that is the property store and you can use `.ItemState` directly instead.
+---@param key string
+---@return any value
+function LuaItem:Get(key) end
+
+---Set item overlay text (like count, but also for non-consumables).
+---(Only available in PopTracker)
+---@param text string
+function LuaItem:SetOverlay(text) end
+
+---Set item overlay background color (default transparent).
+---PopTracker, since 0.17.0.
+---@param background string "#rgb", "#rrggbb", "#argb", "#aarrggbb" or "" (transparent)
+function LuaItem:SetOverlayBackground(background) end
+
+---Set font size for item overlay text in ~pixels.
+---PopTracker, since 0.17.2
+---@param fontSize integer
+function LuaItem:SetOverlayFontSize(fontSize) end
+
+
+---- JsonItem ----
+
+---@class JsonItem
+JsonItem = {}
+
+---Get or set the item's image. Use `ImageReference:FromPackRelativePath` to create an `ImageRef`.
+---For performance reasons, using a staged item is recommended.
+---Currently only works for items of type toggle and static.
+-- Available since 0.26.0
+---@type ImageRef?
+JsonItem.Icon = nil
+
+---Enable/disable item
+---@type boolean
+JsonItem.Active = false
+
+---Set/get stage for staged items.
+---@type integer
+JsonItem.CurrentStage = 0
+
+---Set/get current amount for consumables.
+---@type integer
+JsonItem.AcquiredCount = 0
+
+---Set/get min amount for consumables.
+---Available since 0.21.0.
+---@type integer
+JsonItem.MinCount = 0
+
+---Set/get max amount for consumables.
+---Available since 0.14.0.
+---@type integer
+JsonItem.MaxCount = 0
+
+---Set/get the increment (left-click) value of consumables.
+---@type integer
+JsonItem.Increment = 1
+
+---Set/get the decrement (right-click) value of consumables.
+JsonItem.Decrement = 1
+
+---At the moment (since 0.18.2) an empty table for compatibility reasons.
+---@type table
+JsonItem.Owner = {}
+
+---Gets the type of the item as string ("toggle, ...").
+---Available since 0.23.0.
+JsonItem.Type = ""
+
+---Set item overlay text (like count, but also for non-consumables).
+---(Only available in PopTracker)
+---@param text string
+function JsonItem:SetOverlay(text) end
+
+---Set item overlay background color (default transparent).
+---PopTracker, since 0.17.0.
+---@param background string "#rgb", "#rrggbb", "#argb", "#aarrggbb" or "" (transparent)
+function JsonItem:SetOverlayBackground(background) end
+
+---Set font size for item overlay text in ~pixels.
+---PopTracker, since 0.17.2
+---@param fontSize integer
+function JsonItem:SetOverlayFontSize(fontSize) end
+
+
+---- Location ----
+
+---@class Location
+Location = {}
+
+---Read-only, giving one of the `AccssibilityLevel` constants (will not give CLEARED at the moment).
+---Available since 0.25.5.
+---@type accessibilityLevel
+Location.AccessibilityLevel = 0
+
+
+---- LocationSection ----
+
+---@class LocationSection
+LocationSection = {}
+
+---Is an empty table at the moment for compatibility reasons.
+---@type table
+LocationSection.Owner = {}
+
+---Read-only, total number of Chests in the section.
+---@type integer
+LocationSection.ChestCount = 1
+
+---Read/write how many chests are NOT checked/opened.
+---@type integer
+LocationSection.AvailableChestCount = 1
+
+---Read-only, giving one of the `AccessibilityLevel` constants.
+---@type accessibilityLevel
+LocationSection.AccessibilityLevel = 0

--- a/doc/AUTOTRACKING.md
+++ b/doc/AUTOTRACKING.md
@@ -36,7 +36,8 @@ provided, either through auto-detection (not implemented), variant's flags
 
 
 ### global AutoTracker
-Reading from AutoTracker may be slower than reading from Segment (watch callback argument). `baseaddr`+`offset` is the absolute memory address.
+Reading from AutoTracker may be slower than reading from Segment (watch callback argument).
+`baseaddr`+`offset` is the absolute memory address.
 * `int :ReadU8(baseaddr[,offset])` read 8bit unsigned integer, may return 0 if not yet cached
 * `int :ReadU16(baseaddr[,offset])` as above, 16bit
 * `int :ReadU24(baseaddr[,offset])` as above, 24bit
@@ -61,7 +62,7 @@ ScriptHost:LoadScript("scripts/autotracking.lua")
 
 -- autotracking.lua
 
-function updateAlchemy(mem)
+local updateAlchemy = function(mem)
     local b = mem:ReadUInt8(0x7E2258)
     Tracker:FindObjectForCode("acid_rain").Active = (b & 0x01)>0 -- Acid Rain
     -- etc.
@@ -86,16 +87,15 @@ if available, also add the flag `"uatbridge"`.
 * `:AddVariableWatch(name, {variable_name, ...}, callback[, interval_in_ms])` returns a reference (name) to the watch
 * `:RemoveVariableWatch(name)`
 * callback signature:
-`function(Store, {changed_variable_name, ...})` (see [type Store](#type-store))
+`function(store, {changedVariable_name, ...})` (see [type VariableStore](#type-variablestore))
 
 
 ### global AutoTracker
-Reading from AutoTracker may be slower than reading from Store (watch callback argument).
+Reading from AutoTracker is deprecated. Use watch and read from store (callback argument) instead.
 * `variant :ReadVariable(variable_name)` returns what the remote sent for the variable_name
 
 
-### type Store
-Reading from Store (watch callback argument) is preferred.
+### type VariableStore
 * `variant :ReadVariable(variable_name)` returns what the remote sent for the variable_name
 
 
@@ -104,14 +104,14 @@ Reading from Store (watch callback argument) is preferred.
 ```lua
 -- init.lua
 
-if AutoTracker.ReadVariable then
+if ScriptHost.AddVariableWatch then
     ScriptHost:LoadScript("scripts/autotracking.lua")
 end
 
 
 -- autotracking.lua
 
-function updateAlchemy(store)
+local updateAlchemy = function(store)
     Tracker:FindObjectForCode("acid_rain").Active = store:ReadVariable("acid_rain")>0 -- Acid Rain
     -- etc.
 end

--- a/doc/PACKS.md
+++ b/doc/PACKS.md
@@ -85,6 +85,15 @@ NOTE: User overrides for settings are merged with the pack, replacing individual
 
   you can have global items in `items/items.json` OR per-variant items in `[variant]/items/item.json`
 
+* To get proper auto-complete, type hints and warnings for the PopTracker API, you can use
+  [LuaLS](https://github.com/LuaLS/lua-language-server?tab=readme-ov-file#lua-language-server)
+  (VSCode/ium extension: search for `sumneko.lua`)
+  with our [Definition File](../api/lua/definition/poptracker.lua).\
+  You have to add a `.luarc.json` [(example)](../examples/uat-example/.luarc.json)
+  with the correct path (typically `../../api/lua/definition`) to your project and restart the Language Server or IDE.\
+  It is recommended to check that file into Git, but exclude it from the final pack when zipping.
+
+
 The following interfaces are provided:
 
 
@@ -108,9 +117,11 @@ The following interfaces are provided:
   * `require` behaves mostly like Lua require since 0.25.6
     * `"foo.baz"` will try `/scripts/foo/baz.lua`, `/scripts/foo/baz/init.lua`, `/foo/baz.lua` and `/foo/baz/init.lua`
   * `...` contains mod name for relative require since 0.25.6
-* `bool :AddMemoryWatch(name,addr,len,callback,interal)`: add a memory watch for auto-tracking, see [AUTOTRACKING.md](AUTOTRACKING.md)
+* `ref :AddMemoryWatch(name,addr,len,callback,interal)`: add a memory watch for auto-tracking, see [AUTOTRACKING.md](AUTOTRACKING.md)
 * `bool :RemoveMemoryWatch(name)`: remove memory watch by name, available since 0.11.0
-* `bool :AddWatchForCode(name,code,callback)`: callback(code) will be called whenever an item changed state that canProvide(code). Only available in PopTracker, since 0.11.0, will return a reference (name) to the watch since 0.18.2. Use "*" to trigger for all codes since 0.25.5.
+* `ref :AddVariableWatch(name,{variables, ...},callback,interal)`: add a variable watch for auto-tracking, see [AUTOTRACKING.md](AUTOTRACKING.md)
+* `bool :RemoveVariableWatch(name)`: remove variable watch by name, available since 0.16.0
+* `ref :AddWatchForCode(name,code,callback)`: callback(code) will be called whenever an item changed state that canProvide(code). Only available in PopTracker, since 0.11.0, will return a reference (name) to the watch since 0.18.2. Use "*" to trigger for all codes since 0.25.5.
 * `bool :RemoveWatchForCode(name)`: remove watch by name
 * `LuaItem :CreateLuaItem()`: create a LuaItem (custom item) instance
 
@@ -124,6 +135,7 @@ The following interfaces are provided:
 
 `use ImageRef = string`
 * `ImageRef :FromPackRelativePath(filename)`: for now this will just return filename and path resoltuion is done later.
+* `ImageRef :FromImageReference(original, mod)`: return ImageRef that is original ImageRef + mod string.
 
 
 ### global PopVersion

--- a/examples/ap-storage-example/.luarc.json
+++ b/examples/ap-storage-example/.luarc.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+    "workspace.library": ["../../api/lua/definition"],
+    "runtime.version": "Lua 5.4"
+}

--- a/examples/ap-storage-example/scripts/autotracking.lua
+++ b/examples/ap-storage-example/scripts/autotracking.lua
@@ -11,9 +11,10 @@
 -- Alternatively try-catch (pcall) can be used to handle unexpected values.
 
 
-function onRetrieved(key, val)
+local onRetrieved = function(key, val)
     local o = Tracker:FindObjectForCode(key)
     -- a is toggle, b is consumable, c is progressive toggle
+    ---@cast o JsonItem
     if key == "a" then
         if type(val) == "number" then; o.Active = val > 0
         elseif type(val) == "string" then; o.Active = val ~= ""
@@ -41,7 +42,7 @@ function onRetrieved(key, val)
 end
 
 
-function onClear()
+local onClear = function()
     Archipelago:SetNotify({"a", "b", "c"}) -- listen for changes
     Archipelago:Get({"a", "b", "c"}) -- ask for current values
 end
@@ -51,4 +52,3 @@ Archipelago:AddClearHandler("Clear", onClear) -- called when connecting
 Archipelago:AddRetrievedHandler("Retrieved", onRetrieved) -- called when doing Get
 Archipelago:AddSetReplyHandler("Retrieved", onRetrieved) -- called when a watched value got updated
 print("running!")
-

--- a/examples/hosted_item/.luarc.json
+++ b/examples/hosted_item/.luarc.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+    "workspace.library": ["../../api/lua/definition"],
+    "runtime.version": "Lua 5.4"
+}

--- a/examples/hosted_item/locations/locations.jsonc
+++ b/examples/hosted_item/locations/locations.jsonc
@@ -33,7 +33,7 @@
                         "item_count": 1,
                         "hosted_item": "e",
                         "access_rules": [
-                            "$some_rule"
+                            "$SomeRule"
                         ]
                     }
                 ]

--- a/examples/hosted_item/scripts/init.lua
+++ b/examples/hosted_item/scripts/init.lua
@@ -5,6 +5,6 @@ Tracker:AddItems("items/items.json")
 --maps
 Tracker:AddMaps("maps/maps.json")
 --locations
-Tracker:AddLocations("locations/locations.json")
+Tracker:AddLocations("locations/locations.jsonc")
 --layouts
 Tracker:AddLayouts("layouts/tracker.json")

--- a/examples/hosted_item/scripts/logic.lua
+++ b/examples/hosted_item/scripts/logic.lua
@@ -1,4 +1,4 @@
-function some_rule()
+function SomeRule()
     print("Testing some rule")
     return Tracker:ProviderCountForCode("c") -- this is a number, not boolean!
     -- you can do arithmetic:

--- a/examples/luminosity-test/.luarc.json
+++ b/examples/luminosity-test/.luarc.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+    "workspace.library": ["../../api/lua/definition"],
+    "runtime.version": "Lua 5.4"
+}

--- a/examples/margin-test/.luarc.json
+++ b/examples/margin-test/.luarc.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+    "workspace.library": ["../../api/lua/definition"],
+    "runtime.version": "Lua 5.4"
+}

--- a/examples/uat-example/.luarc.json
+++ b/examples/uat-example/.luarc.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+    "workspace.library": ["../../api/lua/definition"],
+    "runtime.version": "Lua 5.4"
+}

--- a/examples/uat-example/scripts/autotracking.lua
+++ b/examples/uat-example/scripts/autotracking.lua
@@ -11,11 +11,12 @@
 -- * for chests this is left as an exercise for the reader
 -- Alternatively try-catch (pcall) can be used to handle unexpected values.
 
-function updateToggles(store, vars)
+local updateToggles = function(store, vars)
     print("updateToggles")
     for _, var in ipairs(vars) do
         local o = Tracker:FindObjectForCode(var)
         local val = store:ReadVariable(var)
+        ---@cast o JsonItem
         if type(val) == "number" then; o.Active = val > 0
         elseif type(val) == "string" then; o.Active = val ~= ""
         else; o.Active = not(not val)
@@ -24,11 +25,12 @@ function updateToggles(store, vars)
     end
 end
 
-function updateConsumables(store, vars)
+local updateConsumables = function(store, vars)
     print("updateConsumables")
     for _, var in ipairs(vars) do
         local o = Tracker:FindObjectForCode(var)
         local val = store:ReadVariable(var)
+        ---@cast o JsonItem
         if type(val) == "number" then; o.AcquiredCount = val
         else; o.AcquiredCount = 0
         end
@@ -36,11 +38,12 @@ function updateConsumables(store, vars)
     end
 end
 
-function updateProgressiveToggles(store, vars)
+local updateProgressiveToggles = function(store, vars)
     print("updateProgressiveToggles")
     for _, var in ipairs(vars) do
         local o = Tracker:FindObjectForCode(var)
         local val = store:ReadVariable(var)
+        ---@cast o JsonItem
         if type(val) == "table" and type(val[2]) == "number" then
             if type(val[1]) == "number" then; o.Active = val[1]>0
             else; o.Active = not(not val[1])
@@ -53,7 +56,7 @@ function updateProgressiveToggles(store, vars)
     end
 end
 
-function updateLocations(store, vars)
+local updateLocations = function(store, vars)
     print("updateLocations")
     -- if the variable is not named the same as the location
     -- you'll have to map them to actual section names
@@ -62,6 +65,7 @@ function updateLocations(store, vars)
     for _, var in ipairs(vars) do
         local o = Tracker:FindObjectForCode("@"..var) -- grab section
         local val = store:ReadVariable(var)
+        ---@cast o LocationSection
         o.AvailableChestCount = o.ChestCount - val -- in this case val = that many chests are looted
     end
 end

--- a/examples/uat-example/scripts/init.lua
+++ b/examples/uat-example/scripts/init.lua
@@ -6,6 +6,6 @@ Tracker:AddLocations("locations/locations.json")
 Tracker:AddItems("items/items.json")
 Tracker:AddLayouts("layouts/standard.json")
 
-if AutoTracker.ReadVariable then
+if ScriptHost.AddVariableWatch then
     ScriptHost:LoadScript("scripts/autotracking.lua")
 end


### PR DESCRIPTION
This adds a LuaLS definition file to PopTracker to get proper auto-complete suggestions, warnings and type hints for Lua files.
LuaLS has a builtin linter and a builtin typing system. The example packs (all but the template pack) were updated to get rid of all linter warnings.

To test the Definition File, create an `api/lua/definition` folder next to your `PopTracker.exe` and put the [PopTracker.lua](https://github.com/black-sliver/PopTracker/blob/lua-ls/api/lua/definition/poptracker.lua) there. Put the [.luarc.json](https://github.com/black-sliver/PopTracker/blob/lua-ls/examples/uat-example/.luarc.json) into your pack. The example path is `../../api/lua/definition`, so this should work if your pack is in `<exe_dir>\packs\...` after creating said folder and file. And then install LuaLS into vscode/ium as described here: https://github.com/black-sliver/PopTracker/blob/lua-ls/doc/PACKS.md#lua-interface

Future versions of PopTracker will ship with the api folder already in it, so only the .luarc.json and addin will be required.