### PR TITLE
Lua: add OnFrame event

### DIFF
--- a/api/lua/definition/poptracker.lua
+++ b/api/lua/definition/poptracker.lua
@@ -148,12 +148,14 @@ function ScriptHost:RemoveVariableWatch(name) end
 function ScriptHost:CreateLuaItem() end
 
 ---Add a handler/callback that runs on every frame.
+---Available since 0.25.9.
 ---@param name string identifier/name of this callback
----@param callback fun():nil called every frame
+---@param callback fun(elapsedSeconds:number):nil called every frame, argument is elapsed time in seconds since last call
 ---@return string reference for RemoveOnFrameHandler
 function ScriptHost:AddOnFrameHandler(name, callback) end
 
 ---Remove a handler/callback added by AddOnFrameHandler(name).
+---Available since 0.25.9.
 ---@param name string identifier/name of the handler to remove
 ---@return boolean true on success
 function ScriptHost:RemoveOnFrameHandler(name) end

--- a/api/lua/definition/poptracker.lua
+++ b/api/lua/definition/poptracker.lua
@@ -147,6 +147,17 @@ function ScriptHost:RemoveVariableWatch(name) end
 ---@return LuaItem 
 function ScriptHost:CreateLuaItem() end
 
+---Add a handler/callback that runs on every frame.
+---@param name string identifier/name of this callback
+---@param callback fun():nil called every frame
+---@return string reference for RemoveOnFrameHandler
+function ScriptHost:AddOnFrameHandler(name, callback) end
+
+---Remove a handler/callback added by AddOnFrameHandler(name).
+---@param name string identifier/name of the handler to remove
+---@return boolean true on success
+function ScriptHost:RemoveOnFrameHandler(name) end
+
 
 ---- AutoTracker ----
 

--- a/doc/PACKS.md
+++ b/doc/PACKS.md
@@ -125,6 +125,8 @@ The following interfaces are provided:
 * `ref :AddWatchForCode(name,code,callback)`: callback(code) will be called whenever an item changed state that canProvide(code). Only available in PopTracker, since 0.11.0, will return a reference (name) to the watch since 0.18.2. Use "*" to trigger for all codes since 0.25.5.
 * `bool :RemoveWatchForCode(name)`: remove watch by name
 * `LuaItem :CreateLuaItem()`: create a LuaItem (custom item) instance
+* `ref :AddOnFrameHandler(name,callback)`: callback(elapsed) will be called every frame, available since 0.25.9
+* `bool :RemoveOnFrameHandler(name)`: remove a frame callback
 
 
 ### global AutoTracker

--- a/src/core/scripthost.h
+++ b/src/core/scripthost.h
@@ -3,6 +3,7 @@
 
 #include <luaglue/luainterface.h>
 #include <luaglue/lua_json.h>
+#include <luaglue/luapp.h>
 #include "pack.h"
 #include "autotracker.h"
 #include "tracker.h"
@@ -27,10 +28,12 @@ public:
     bool RemoveWatchForCode(const std::string& name);
     std::string AddVariableWatch(const std::string& name, const json& variables, LuaRef callback, int interval);
     bool RemoveVariableWatch(const std::string& name);
+    std::string AddOnFrameHandler(const std::string& name, LuaRef callback);
+    bool RemoveOnFrameHandler(const std::string& name);
     void resetWatches();
     
-    // This is called every frame to run auto-tracking
-    bool autoTrack();
+    // This is called every frame. Returns true if state was changed by auto-tracking.
+    bool onFrame();
 
     void runMemoryWatchCallbacks();
 
@@ -64,7 +67,51 @@ protected:
     std::vector<MemoryWatch> _memoryWatches;
     std::vector<std::pair<std::string, CodeWatch> > _codeWatches;
     std::vector<std::pair<std::string, VarWatch> > _varWatches;
+    std::vector<std::pair<std::string, LuaRef> > _onFrameCallbacks;
     AutoTracker *_autoTracker = nullptr;
+
+private:
+    // This will be called every frame to run auto-tracking
+    bool autoTrack();
+    // Run a Lua function defined in ref, return bool its result as boolean.
+    // ArgsHook can push arguments to the stack and return the number of pushed arguments.
+    template <class T>
+    int runLuaFunction(int ref, const std::string& name, T& res, std::function<int(lua_State*)> argsHook=nullptr, int execLimit=0)
+    {
+        lua_pushcfunction(_L, Tracker::luaErrorHandler);
+        lua_rawgeti(_L, LUA_REGISTRYINDEX, ref);
+        int nargs = argsHook ? argsHook(_L) : 0;
+        if (execLimit > 0)
+            lua_sethook(_L, Tracker::luaTimeoutHook, LUA_MASKCOUNT, execLimit);
+        int status = lua_pcall(_L, nargs, 1, -nargs-2);
+        if (execLimit > 0)
+            lua_sethook(_L, nullptr, 0, 0);
+
+        if (status) {
+            auto err = lua_tostring(_L, -1);
+            if (err)
+                printf("Error calling %s: %s\n", name.c_str(), err);
+            else
+                printf("Error calling %s (%d)\n", name.c_str(), status);
+            lua_pop(_L, 2); // error + error func
+            return status;
+        } else {
+            try {
+                res = Lua(_L).Get<T>(-1);
+            } catch (std::invalid_argument&) {
+                lua_pop(_L, 2); // result + error func
+                return -1;
+            }
+            lua_pop(_L, 2); // result + error func
+            return LUA_OK;
+        }
+    }
+
+    int runLuaFunction(int ref, const std::string& name, std::function<int(lua_State*)> argsHook=nullptr, int execLimit=0)
+    {
+        bool ignore;
+        return runLuaFunction<bool>(ref, name, ignore, argsHook, execLimit);
+    }
 
 protected: // Lua interface implementation
     static constexpr const char Lua_Name[] = "ScriptHost";

--- a/src/core/scripthost.h
+++ b/src/core/scripthost.h
@@ -10,6 +10,7 @@
 #include "luaitem.h"
 #include <string>
 #include <vector> // TODO: replace by new[] uint8_t?
+#include "../uilib/timer.h"
 
 class ScriptHost;
 
@@ -59,7 +60,14 @@ public:
         int callback;
         std::set<std::string> names;
     };
-    
+
+    struct OnFrameHandler
+    {
+        int callback;
+        std::string name;
+        Ui::microtick_t lastTimestamp;
+    };
+
 protected:
     lua_State *_L;
     Pack *_pack;
@@ -67,7 +75,7 @@ protected:
     std::vector<MemoryWatch> _memoryWatches;
     std::vector<std::pair<std::string, CodeWatch> > _codeWatches;
     std::vector<std::pair<std::string, VarWatch> > _varWatches;
-    std::vector<std::pair<std::string, LuaRef> > _onFrameCallbacks;
+    std::vector<OnFrameHandler> _onFrameHandlers;
     AutoTracker *_autoTracker = nullptr;
 
 private:

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -27,6 +27,9 @@ public:
     
     Tracker(Pack* pack, lua_State *L);
     virtual ~Tracker();
+
+    static int luaErrorHandler(lua_State *L);
+    static void luaTimeoutHook(lua_State *L, lua_Debug *);
     
     // TODO: Use a helper to access Lua. This code doesn't belong in tracker
     // Attempt to call a lua func and return an integer value
@@ -102,6 +105,7 @@ public:
     bool changeItemState(const std::string& id, BaseItem::Action action);
 
     static void setExecLimit(int execLimit);
+    static int getExecLimit();
 
 protected:
     Pack* _pack;

--- a/src/poptracker.cpp
+++ b/src/poptracker.cpp
@@ -722,7 +722,8 @@ bool PopTracker::frame()
         // when all tasks are done, poll() will stop(). Reset for next request.
         if (_asio->stopped()) _asio->restart();
     }
-    if (_scriptHost) _scriptHost->autoTrack();
+    if (_scriptHost)
+        _scriptHost->onFrame();
 
     auto now = std::chrono::steady_clock::now();
 


### PR DESCRIPTION
Adds `ScriptHost:AddOnFrameHandler` and `ScriptHost:RemoveOnFrameHandler` to run Lua code every frame.

Also minor cleanup in ScriptHost to avoid duplicate code when calling Lua functions and added Execution Limit for Memory Watches as a side-effect.