### PR TITLE
Map: default to split color locations

### DIFF
--- a/src/ui/mapwidget.cpp
+++ b/src/ui/mapwidget.cpp
@@ -68,7 +68,7 @@ static const int triangleValues[16][4] = {
 
 Widget::Color MapWidget::StateColors[] = _DEFAULT_STATE_COLORS;
 
-bool MapWidget::SplitRects = false;
+bool MapWidget::SplitRects = true;
 
 
 MapWidget::MapWidget(int x, int y, int w, int h, const char* path)


### PR DESCRIPTION
instead of mixed colors. For installations that never toggled the setting before.