### PR TITLE
Doc: qusb fixed the typo in the filename

### DIFF
--- a/doc/AUTOTRACKING.md
+++ b/doc/AUTOTRACKING.md
@@ -3,7 +3,7 @@
 ## Supported Interfaces
 
 * Memory
-  * [USB2SNES websocket protocol](https://github.com/Skarsnik/QUsb2snes/blob/master/docs/Procotol.md)
+  * [USB2SNES websocket protocol](https://github.com/Skarsnik/QUsb2snes/blob/master/docs/Protocol.md)
     as provided by QUsb2Snes, Usb2Snes and SNI
   * Lua connector provided by the [CrowdControl SDK](https://developer.crowdcontrol.live/sdk/)
 * Variables


### PR DESCRIPTION
File we linked to was renamed to fix a typo, we now have to fix it as well.