### PR TITLE
CI: use macos-13

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -69,7 +69,7 @@ jobs:
         if-no-files-found: error
 
   build-macos:
-    runs-on: macos-latest
+    runs-on: macos-13
     
     steps:
     - name: Install dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,7 +101,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release-macos:
-    runs-on: macos-latest
+    runs-on: macos-13
 
     steps:
     - name: Install dependencies

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,7 @@ jobs:
 
   test-macos:
 
-    runs-on: macos-latest
+    runs-on: macos-13
     
     steps:
     - name: Install dependencies


### PR DESCRIPTION
* Release build targets older macos.
* Test build currently fails to find headers sdl2-config --cflags on -latest