### PR TITLE
JsonItem: ignore allow_disabled for Toggle, Static and Toggle Badged

### DIFF
--- a/doc/PACKS.md
+++ b/doc/PACKS.md
@@ -287,6 +287,9 @@ a table representing an enum with the following constants: \
   + adds `disabled_img_mods`: like `img_mods` but for off. Defaults to `img_mods` + `"@disabled"`). Any value (e.g. `"none"`) disables defaults.
   + adds `initial_active_state`: precollected if true, since 0.25.4
 
++ `"static"`:
+  + behaves like a toggle that is always on
+
 * `"consumable"`:
   + has AcquiredCount (0 = grey/disabled)
   + adds `"min_quantity": 0`, since 0.21.0

--- a/src/core/jsonitem.cpp
+++ b/src/core/jsonitem.cpp
@@ -47,29 +47,16 @@ JsonItem JsonItem::FromJSON(json& j)
     
     item._name          = to_string(j["name"], "");
     item._type          = Str2Type(to_string(j["type"], ""));
-    
-    if (item._type == Type::STATIC) {
-        item._allowDisabled = false;
-        item._stage1 = 1;
-    } else /*if (item._type == Type::TOGGLE)*/ {
-        item._allowDisabled = true; // default to true
-    }
-    
+
     item._capturable    = to_bool(j["capturable"], false);
     item._loop          = to_bool(j["loop"], false);
-    item._allowDisabled = to_bool(j["allow_disabled"], item._allowDisabled);
+    item._allowDisabled = to_bool(j["allow_disabled"], true);
     item._img           = to_string(j["img"], "");
     item._disabledImg   = to_string(j["disabled_img"], item._img);
     item._minCount      = to_int(j["min_quantity"], 0);
     item._maxCount      = to_int(j["max_quantity"], -1);
     item._increment     = to_int(j["increment"], 1);
     item._decrement     = to_int(j["decrement"], item._increment);
-
-    if (item._type == Type::PROGRESSIVE_TOGGLE) {
-        item._loop = true;
-        item._allowDisabled = true;
-    }
-
     item._overlayBackground = to_string(j["overlay_background"], "");
     item._overlayAlign = to_string(j["overlay_align"], "");
     item._overlayFontSize = to_int(j["overlay_font_size"], to_int(j["badge_font_size"], 0));
@@ -82,6 +69,16 @@ JsonItem JsonItem::FromJSON(json& j)
     else
         defaultDisabledImgMods += ",@disabled";
     commasplit(to_string(j["disabled_img_mods"], defaultDisabledImgMods), item._disabledImgMods);
+
+    if (item._type == Type::TOGGLE || item._type == Type::TOGGLE_BADGED) {
+        item._allowDisabled = true; // always true
+    } else if (item._type == Type::PROGRESSIVE_TOGGLE) {
+        item._loop = true;
+        item._allowDisabled = true;
+    } else if (item._type == Type::STATIC) {
+        item._allowDisabled = false; // always false
+        item._stage1 = 1;
+    }
 
     if (j["stages"].type() == json::value_t::array) {
         for (auto& v: j["stages"]) {


### PR DESCRIPTION
Ignore `"allow_disabled"` for toggle, static and toggle_badged. It was never documented that it does something.

Also make internal handling of `allowDisabled` more consistent.