### PR TITLE
Archipelago: Allow sending client status for manual (GOAL)

### DIFF
--- a/api/lua/definition/poptracker.lua
+++ b/api/lua/definition/poptracker.lua
@@ -15,7 +15,7 @@
 
 ---Currently running PopTracker version as string "x.y.z".
 ---@type string
-PopVersion = "0.26.2"
+PopVersion = "0.27.1"
 -- Actual value comes from the program, not from here, but try to keep in sync with API version here.
 
 ---Set to true to get more error or debug output.
@@ -302,6 +302,14 @@ function VariableStore:ReadVariable(variableName) end
 ---@class Archipelago
 Archipelago = {}
 
+---@enum archipelagoCientStatus
+Archipelago.ClientStatus = {
+    UNKNOWN = 0,
+    READY = 10,
+    PLAYING = 20,
+    GOAL = 30,
+}
+
 ---The slot number of the connected player or -1 if not connected.
 ---@type integer
 Archipelago.PlayerNumber = -1
@@ -387,6 +395,12 @@ function Archipelago:LocationChecks(locations) end
 ---@param sendAsHint integer
 ---@return boolean true on success
 function Archipelago:LocationScouts(locations, sendAsHint) end
+
+---Send client status to the server. This is used to send the goal / win condition.
+---Supported since 0.27.1, only allowed if "apmanual" flag is set in manifest.
+---@param status archipelagoCientStatus
+---@return boolean true on success
+function Archipelago:StatusUpdate(status) end
 
 
 ---- ImageRef ----

--- a/api/lua/definition/poptracker.lua
+++ b/api/lua/definition/poptracker.lua
@@ -190,7 +190,7 @@ function ScriptHost:RemoveOnFrameHandler(name) end
 ---Any kind of filtering and detection what changed has to be done inside the callback.
 ---Available since 0.26.2.
 ---@param name string identifier/name of this callback
----@param callback func(section:LocationSection):nil called when any location section changed
+---@param callback fun(section:LocationSection):nil called when any location section changed
 ---@return string reference for RemoveOnLocationSectionChangedHandler
 function ScriptHost:AddOnLocationSectionChangedHandler(name, callback) end
 

--- a/src/ap/aptracker.h
+++ b/src/ap/aptracker.h
@@ -274,6 +274,15 @@ public:
         return _ap->LocationScouts(locations, createAsHint);
     }
 
+    /// Returns true if sending a client status update to the server.
+    /// This is used to send the goal / win condition.
+    bool StatusUpdate(APClient::ClientStatus status)
+    {
+        if (!_allowSend || !_ap)
+            return false;
+        return _ap->StatusUpdate(status);
+    }
+
     Signal<const std::string&> onError;
     Signal<APClient::State> onStateChanged;
     Signal<const json&> onClear; // called when state has to be cleared, gives new slot_data

--- a/src/ap/archipelago.h
+++ b/src/ap/archipelago.h
@@ -28,6 +28,7 @@ public:
     bool Get(const json& keys);
     bool LocationChecks(const json& locations);
     bool LocationScouts(const json& locations, int sendAsHint);
+    bool StatusUpdate(int status);
 
 protected:
     lua_State *_L;


### PR DESCRIPTION
also fixes a typo in `ScriptHost:AddOnLocationSectionChangedHandler` that would make LuaLS complain about correct use.

Example used for testing:
```lua
ScriptHost:AddWatchForCode("victory", "carltrons_robot", function(code)
    local o = Tracker:FindObjectForCode(code)
    ---@cast o JsonItem
    if o.Active then
        local res = Archipelago:StatusUpdate(Archipelago.ClientStatus.GOAL)
        if res then
            print("Sent victory")
        else
            print("Error sending victory")
        end
    end
end)
```