### PR TITLE
CI: ignore brew non-zero exit code

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -74,7 +74,7 @@ jobs:
     steps:
     - name: Install dependencies
       run: |
-        brew install coreutils SDL2 sdl2_ttf sdl2_image openssl@1.1 automake libtool autoconf googletest
+        brew install coreutils SDL2 sdl2_ttf sdl2_image openssl@1.1 automake libtool autoconf googletest || true
     - uses: actions/checkout@v4
       with:
         submodules: recursive

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,7 +106,7 @@ jobs:
     steps:
     - name: Install dependencies
       run: |
-        brew install coreutils SDL2 sdl2_ttf sdl2_image openssl@1.1 automake libtool autoconf googletest
+        brew install coreutils SDL2 sdl2_ttf sdl2_image openssl@1.1 automake libtool autoconf googletest || true
     - uses: actions/checkout@v4
       with:
         submodules: recursive

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,7 +51,7 @@ jobs:
     - name: Install dependencies (brew)
       if: ${{ startsWith(matrix.os, 'macos') }}
       run: |
-        brew install coreutils SDL2 sdl2_ttf sdl2_image openssl@1.1 googletest
+        brew install coreutils SDL2 sdl2_ttf sdl2_image openssl@1.1 googletest || true
     - name: Install dependencies (msys2)
       if: ${{ startsWith(matrix.os, 'windows') }}
       uses: msys2/setup-msys2@v2


### PR DESCRIPTION
Hopefully we catch the problem if a later step fails, but link ~~warning~~ error returning non-zero stops us from running tests. Brew reports errors and warnings in a way that is compatible to GH messages, so the error is visible in the run overview.