### PR TITLE
Ignore unicode for auto-save path and special symbols for default filename

### DIFF
--- a/src/core/statemanager.cpp
+++ b/src/core/statemanager.cpp
@@ -1,21 +1,12 @@
 #include "statemanager.h"
 #include "jsonutil.h"
 #include "fileutil.h"
+#include "util.h"
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 
 std::map<StateManager::StateID, json> StateManager::_states;
 std::string StateManager::_dir;
-
-static std::string sanitize_dir(std::string s)
-{
-    if (s.empty()) return "_";
-    if ((size_t)std::count(s.begin(), s.end(), '.') == s.length()) return "_";
-    std::replace(s.begin(), s.end(), '/', '_');
-    std::replace(s.begin(), s.end(), '\\', '_');
-    std::replace(s.begin(), s.end(), ':', '_');
-    return s;
-}
 
 void StateManager::setDir(const std::string& dir)
 {

--- a/src/core/util.h
+++ b/src/core/util.h
@@ -1,7 +1,10 @@
 #ifndef _CORE_UTIL_H
 #define _CORE_UTIL_H
 
-#include <stddef.h>
+#include <algorithm>
+#include <cstddef>
+#include <cstring>
+
 
 template< class Type, ptrdiff_t n >
 static ptrdiff_t countOf( Type (&)[n] ) { return n; }
@@ -12,10 +15,25 @@ static std::string sanitize_print(const std::string& s) {
     return res;
 }
 
-static std::string sanitize_filename(const std::string& s) {
-    std::string res = s;
-    for (auto& c: res) if (c<0x20 || c=='/' || c=='\\' || c==':') c = '_';
-    return res;
+/// Replaces reserved/non-portable symbols by '_'.
+static std::string sanitize_filename(std::string s) {
+    auto exclude = "<>:\"/\\|?*$'`";
+    auto sanitize = [&](char c) { return strchr(exclude, c) || c == 0; };
+    std::replace_if(s.begin(), s.end(), sanitize, '_');
+    return s;
+}
+
+/// Replaces non-ASCII and reserved/non-portable symbols by '_'. Returns "_" for empty and resrved folder names.
+static std::string sanitize_dir(std::string s)
+{
+    if (s.empty())
+        return "_";
+    if ((size_t)std::count(s.begin(), s.end(), '.') == s.length())
+        return "_";
+    auto exclude = "<>:\"/\\|?*$'`";
+    auto sanitize = [&](char c) { return c<0x20 || strchr(exclude, c); };
+    std::replace_if(s.begin(), s.end(), sanitize, '_');
+    return s;
 }
 
 template<typename T>

--- a/test/core/test_util.cpp
+++ b/test/core/test_util.cpp
@@ -1,0 +1,41 @@
+#include <gtest/gtest.h>
+#include "../../src/core/util.h"
+
+
+TEST(SanitizeFilenameTest, InvalidSymbol) {
+    EXPECT_EQ(sanitize_filename({"a\x00z", 3}), "a_z");
+    EXPECT_EQ(sanitize_filename("ä"), "ä");
+    EXPECT_EQ(sanitize_filename("a*b"), "a_b");
+    EXPECT_EQ(sanitize_filename("a/b"), "a_b");
+    EXPECT_EQ(sanitize_filename("a\\b"), "a_b");
+}
+
+TEST(SanitizeFilenameTest, Empty) {
+    // allow empty filename
+    EXPECT_EQ(sanitize_filename(""), "");
+}
+
+TEST(SanitizeDirTest, InvalidSymbol) {
+    EXPECT_EQ(sanitize_dir({"a\x00z", 3}), "a_z");
+    EXPECT_EQ(sanitize_dir("a\x01z"), "a_z");
+    EXPECT_EQ(sanitize_dir("a\x80z"), "a_z");
+    EXPECT_EQ(sanitize_dir("a*b"), "a_b");
+    EXPECT_EQ(sanitize_dir("a/b"), "a_b");
+    EXPECT_EQ(sanitize_dir("a\\b"), "a_b");
+}
+
+TEST(SanitizeDirTest, Empty) {
+    // can't have an empty dirname
+    EXPECT_EQ(sanitize_dir(""), "_");
+}
+
+TEST(SanitizeDirTest, NoCWD) {
+    EXPECT_EQ(sanitize_dir("."), "_");
+    EXPECT_EQ(sanitize_dir("./"), "._");
+}
+
+TEST(SanitizeDirTest, NoParent) {
+    EXPECT_EQ(sanitize_dir(".."), "_");
+    EXPECT_EQ(sanitize_dir("../"), ".._");
+    EXPECT_EQ(sanitize_dir("..\\"), ".._");
+}


### PR DESCRIPTION
Also refactor and add tests.

Until we use wstring paths on windows, the utf8 paths would be invalid.