### PR TITLE
Version Helper: correct comparison for semver and a.b.c.d notation

### DIFF
--- a/src/core/version.cpp
+++ b/src/core/version.cpp
@@ -1,8 +1,11 @@
 #include "version.h"
+#include <algorithm>
+
 
 Version::Version(int ma, int mi, int r, const std::string& e)
         : Major(ma), Minor(mi), Revision(r), Extra(e)
 {
+    sanitize();
 }
 
 Version::Version(int ma, int mi, int r, int e)
@@ -21,14 +24,11 @@ Version::Version(const std::string& s)
     Minor = (next && *next) ? (int)strtol(next+1, &next, 10) : 0;
     Revision = (next && *next) ? (int)strtol(next+1, &next, 10) : 0;
     Extra = (next && *next) ? next : "";
+    sanitize();
 }
 
 Version::Version()
-    : Major(0), Minor(0), Revision(0), Extra("")
-{
-}
-
-Version::~Version()
+    : Major(0), Minor(0), Revision(0)
 {
 }
 
@@ -40,6 +40,27 @@ bool Version::operator <(const Version& other) const
     if (Minor > other.Minor) return false;
     if (Revision < other.Revision) return true;
     if (Revision > other.Revision) return false;
+    if ((!Extra.empty() && Extra[0] == '.') || (!other.Extra.empty() && other.Extra[0] == '.')) {
+        char* next = nullptr;
+        auto numericExtra = Extra.empty() ? 0 : strtol(Extra.c_str() + 1, &next, 10);
+        char* otherNext = nullptr;
+        auto otherNumericExtra = other.Extra.empty() ? 0 : strtol(other.Extra.c_str() + 1, &otherNext, 10);
+        if ((next == nullptr || *next == 0) && (otherNext == nullptr || *otherNext == 0)) {
+            // not semver; only use result if BOTH are "a.b.c[.d]"
+            return numericExtra < otherNumericExtra;
+        }
+    }
+    auto plusPos = Extra.find('+');
+    auto otherPlusPos = other.Extra.find('+');
+    auto npos = std::string::npos;
+    std::string_view cutExtra(Extra.c_str(), plusPos == npos ? Extra.length() : plusPos);
+    std::string_view otherCutExtra(other.Extra.c_str(), otherPlusPos == npos ? other.Extra.length() : otherPlusPos);
+    if (cutExtra.empty())
+        return false;
+    if (otherCutExtra.empty())
+        return true;
+    if (cutExtra.compare(otherCutExtra) < 0)
+        return true;
     return false;
 }
 
@@ -50,7 +71,14 @@ bool Version::operator >(const Version& other) const
 
 std::string Version::to_string() const
 {
-    if (Extra.empty())
-        return std::to_string(Major) + "." + std::to_string(Minor) + "." + std::to_string(Revision);
-    return std::to_string(Major) + "." + std::to_string(Minor) + "." + std::to_string(Revision) + "-" + Extra;
+    return std::to_string(Major) + "." + std::to_string(Minor) + "." + std::to_string(Revision) + Extra;
+}
+
+void Version::sanitize()
+{
+    // we are a bit more lax than semver here, but this should still allow to compare
+    auto invalid = [&](char c) { return c < '(' || c > '~' || (c > '_' && c < 'a'); };
+    Extra.erase(std::remove_if(Extra.begin(), Extra.end(), invalid), Extra.end());
+    if (!Extra.empty() && Extra[0] != '-' && Extra[0] != '+' && Extra[0] != '.')
+        Extra = "-" + Extra;
 }

--- a/src/core/version.h
+++ b/src/core/version.h
@@ -3,13 +3,14 @@
 
 #include <string>
 
+/// Version parser and comparison utility supporting both semver and a[.b[.c[.d]]] notation
 class Version final {
 public:
     Version(int major, int minor, int revision, const std::string& extra="");
     Version(int major, int minor, int revision, int extra);
     Version(const std::string& s);
     Version();
-    virtual ~Version();
+    virtual ~Version() = default;
     
     int Major;
     int Minor;
@@ -20,6 +21,9 @@ public:
     bool operator>(const Version& other) const;
 
     std::string to_string() const;
+
+private:
+    void sanitize();
 };
 
 #endif /* _CORE_VERSION_H */

--- a/test/core/test_version.cpp
+++ b/test/core/test_version.cpp
@@ -1,0 +1,72 @@
+#include <gtest/gtest.h>
+#include "../../src/core/version.h"
+
+
+TEST(VersionTest, CompareBasic) {
+    EXPECT_TRUE(Version() < Version(0, 0, 1));
+    EXPECT_FALSE(Version(1, 0, 0) < Version(1, 0, 0));
+    EXPECT_FALSE(Version(1, 0, 0) > Version(1, 0, 0));
+    EXPECT_TRUE(Version(2, 0, 0) > Version(1, 1, 1));
+    EXPECT_TRUE(Version(1, 1, 0) > Version(1, 0, 1));
+    EXPECT_TRUE(Version(1, 0, 1) > Version(1, 0, 0));
+    EXPECT_TRUE(Version(0, 0, 2) > Version(0, 0, 1));
+    EXPECT_FALSE(Version(1, 0, 0) < Version("1"));
+    EXPECT_FALSE(Version(1, 0, 0) < Version("1.0"));
+    EXPECT_FALSE(Version(1, 0, 0) < Version("1.0.0"));
+    EXPECT_TRUE(Version("1.2.3-1something2") < Version("1.2.3-2something1"));
+}
+
+TEST(VersionTest, CompareSemVer) {
+    // semver, no tests for numeric build
+    EXPECT_TRUE(Version("1.0.0") < Version("2.0.0"));
+    EXPECT_TRUE(Version("2.0.0") < Version("2.1.0"));
+    EXPECT_TRUE(Version("2.1.0") < Version("2.1.1"));
+    EXPECT_TRUE(Version("1.0.0-alpha") < Version("1.0.0"));
+    EXPECT_TRUE(Version("1.0.0-alpha") < Version("1.0.0-alpha.1"));
+    EXPECT_TRUE(Version("1.0.0-alpha.1") < Version("1.0.0-alpha.beta"));
+    EXPECT_TRUE(Version("1.0.0-alpha.beta") < Version("1.0.0-beta"));
+    EXPECT_TRUE(Version("1.0.0-alpha.beta") < Version("1.0.0-beta.2"));
+    EXPECT_TRUE(Version("1.0.0-alpha.beta.2") < Version("1.0.0-beta.11"));
+    EXPECT_TRUE(Version("1.0.0-alpha.beta.11") < Version("1.0.0-rc.1"));
+    EXPECT_TRUE(Version("1.0.0-rc.1") < Version("1.0.0"));
+}
+
+TEST(VersionTest, CompareSemVerBuild) {
+    EXPECT_FALSE(Version("1.0.0+1") < Version("1.0.0+2"));
+    EXPECT_FALSE(Version("1.0.0+1") > Version("1.0.0+2"));
+    EXPECT_FALSE(Version("1.0.0-alpha+1") < Version("1.0.0-alpha+2"));
+    EXPECT_FALSE(Version("1.0.0-alpha+1") > Version("1.0.0-alpha+2"));
+}
+
+TEST(VersionTest, CompareNumericBuild) {
+    // numeric build, not semver
+    EXPECT_FALSE(Version(1, 0, 0) < Version(1, 0, 0, 0));
+    EXPECT_FALSE(Version(1, 0, 0, 0) < Version(1, 0, 0));
+    EXPECT_FALSE(Version(1, 0, 0) < Version(1, 0, 0, 0));
+    EXPECT_FALSE(Version("1.0.0.0") < Version(1, 0, 0));
+    EXPECT_FALSE(Version(1, 0, 0) < Version("1.0.0.0"));
+    EXPECT_FALSE(Version("1.2.3.5") < Version(1, 2, 3, 4));
+    EXPECT_TRUE(Version("1.2.3.4") < Version(1, 2, 3, 5));
+    EXPECT_TRUE(Version(1, 2, 3) < Version("1.2.3.4"));
+}
+
+TEST(VersionTest, ToString) {
+    EXPECT_EQ(Version("1.2.3").to_string(), "1.2.3");
+    EXPECT_EQ(Version("1.2.3.4").to_string(), "1.2.3.4");
+    EXPECT_EQ(Version("1.2.3-alpha.4").to_string(), "1.2.3-alpha.4");
+    EXPECT_EQ(Version("1.2.3+4").to_string(), "1.2.3+4");
+}
+
+TEST(VersionTest, Extra) {
+    auto v1 = Version(1, 2, 3, "extra");
+    auto v2 = Version("1.2.3-extra");
+    EXPECT_FALSE(v1 < v2);
+    EXPECT_FALSE(v2 < v1);
+    EXPECT_EQ(v1.to_string(), v2.to_string());
+}
+
+TEST(VersionTest, InvalidExtra) {
+    EXPECT_EQ(Version("1.2.3'").to_string(), "1.2.3");
+    EXPECT_EQ(Version("1.2.3-'a").to_string(), "1.2.3-a");
+    EXPECT_EQ(Version("1.2.3+'a").to_string(), "1.2.3+a");
+}


### PR DESCRIPTION
also adds a test

Fixes problems where update notification did not work as expected.