### PR TITLE
Ignore invalid URL for text drag&drop

### DIFF
--- a/src/http/http.h
+++ b/src/http/http.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <iostream>
 #include <functional>
-#include <string.h>
+#include <cstring>
 #include <list>
 #include <set>
 #include <map>
@@ -219,10 +219,21 @@ public:
         return true;
     }
 
+    static bool is_uri(const std::string& uri)
+    {
+        std::string proto, host, port, path;
+        return parse_uri(uri, proto, host, port, path);
+    }
+
     static bool parse_uri(const std::string& uri, std::string& proto, std::string& host, std::string& port, std::string& path)
     {
+        auto allowed = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:/?#[]@!$&'()*+,;=%";
+        for (const auto c: uri)
+            if (!strchr(allowed, c))
+                return false;
         std::string::size_type pos = uri.find("://");
-        if (pos == uri.npos) return false;
+        if (pos == uri.npos)
+            return false;
         proto = uri.substr(0, pos);
         std::string::size_type pos2 = uri.find("/", pos+3);
         std::string::size_type pos3 = uri.find(":", pos+3);

--- a/src/poptracker.cpp
+++ b/src/poptracker.cpp
@@ -733,8 +733,13 @@ bool PopTracker::start()
             }
         } else if (type == Ui::DropType::TEXT && strncasecmp(data.c_str(), "https://", 8)==0 && strcasecmp(data.c_str()+data.length()-4, ".zip") == 0) {
             // ask user to download and "install" pack
+            if (!HTTP::is_uri(data)) {
+                fprintf(stderr, "Dropped URI is not valid!\n");
+                return;
+            }
             const char* zipname = strrchr(data.c_str() + 8, '/');
-            if (!zipname) return;
+            if (!zipname)
+                return;
             zipname += 1;
             std::string msg = "Download pack from " + data + " ?";
             if (Dlg::MsgBox("PopTracker", msg, Dlg::Buttons::YesNo, Dlg::Icon::Question) != Dlg::Result::Yes)


### PR DESCRIPTION
Also adds a helper function to validate URLs.

This fixes showing a message box when dragging & droping garbage (only on Linux).