### PR TITLE
Settings: show correct tooltip for progressive

### DIFF
--- a/src/ui/settingswindow.h
+++ b/src/ui/settingswindow.h
@@ -14,6 +14,9 @@ public:
     
     virtual void setTracker(Tracker *tracker) override;
     virtual void render(Renderer renderer, int offX, int offY) override;
+
+private:
+    std::string _tooltipItemId;
 };
 
 } // namespace Ui

--- a/src/uilib/tooltip.cpp
+++ b/src/uilib/tooltip.cpp
@@ -23,4 +23,13 @@ Tooltip::Tooltip(FONT font, const std::string& text)
     addChild(label);
 }
 
+void Tooltip::setText(const std::string &text)
+{
+    if (auto label = dynamic_cast<Label*>(_children.front())) {
+        label->setText(text);
+        label->setSize(label->getAutoSize());
+        relayout();
+    }
+}
+
 } // namespace Ui

--- a/src/uilib/tooltip.h
+++ b/src/uilib/tooltip.h
@@ -24,6 +24,8 @@ public:
     static constexpr int PADDING=8;
     static constexpr int OFFSET=2;
     static constexpr tick_t delay = DEFAULT_TOOLTIP_DELAY;
+
+    void setText(const std::string& text);
 private:
 
 };

--- a/src/uilib/window.h
+++ b/src/uilib/window.h
@@ -25,11 +25,9 @@ protected:
     FontStore *_fontStore = nullptr; // TODO; pass as argument to window constructor?
     FONT _font = nullptr;
 
-private:
     Position _lastMousePos;
     Widget* _tooltip = nullptr;
 
-protected:
     void clear();
     void present();
     virtual void render(Renderer renderer, int offX, int offY) override;


### PR DESCRIPTION
As reported here: https://discord.com/channels/937157230963339364/1277317101966856203

The tooltip in the settings window would show the item name instead of the stage name for progressive items with stage names.