### PR TITLE
Use new version comparison to properly detect pack updates

### DIFF
--- a/src/packmanager/packmanager.cpp
+++ b/src/packmanager/packmanager.cpp
@@ -164,20 +164,18 @@ void PackManager::checkForUpdateFrom(const std::string& uid, const std::string& 
                 Version current = Version(version);
 
                 for (auto& section: j["versions"]) {
-                    if (!section["download_url"].is_string()) continue; // skip "null"
+                    if (!section["download_url"].is_string())
+                        continue; // skip "null"
                     std::string v = section["package_version"].get<std::string>();
-                    if (v.empty()) continue; // skip bad version names
+                    if (v.empty())
+                        continue; // skip bad version names
                     auto ignoreIt = _ignoredSHA256.find(uid);
                     if (ignoreIt != _ignoredSHA256.end() &&
                             ignoreIt->second.count(section["sha256"].get<std::string>())) {
                         break;
                     }
                     Version check = Version(v);
-                    if (check > current || (check.Major == current.Major &&
-                            check.Minor == current.Minor &&
-                            check.Revision == current.Revision &&
-                            check.Extra != current.Extra))
-                    {
+                    if (check > current) {
                         hasUpdate = true;
                         onUpdateAvailable.emit(this,
                                 uid, v,

--- a/test/core/test_version.cpp
+++ b/test/core/test_version.cpp
@@ -45,6 +45,7 @@ TEST(VersionTest, CompareNumericBuild) {
     EXPECT_FALSE(Version(1, 0, 0) < Version(1, 0, 0, 0));
     EXPECT_FALSE(Version("1.0.0.0") < Version(1, 0, 0));
     EXPECT_FALSE(Version(1, 0, 0) < Version("1.0.0.0"));
+    EXPECT_TRUE(Version("1.4.3.0") < Version("1.4.3.1"));
     EXPECT_FALSE(Version("1.2.3.5") < Version(1, 2, 3, 4));
     EXPECT_TRUE(Version("1.2.3.4") < Version(1, 2, 3, 5));
     EXPECT_TRUE(Version(1, 2, 3) < Version("1.2.3.4"));


### PR DESCRIPTION
Removes the work-around we had previously that could see a downgrade as upgrade.

\+ minor code reformatting