### PR TITLE
Make logic resolving 4x faster and allow CI codes for stages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist/
 *~
 .DS_Store
 thumbs.db
+gmon.out
 
 # exclude unused and scratch pad files
 .trash

--- a/api/lua/definition/poptracker.lua
+++ b/api/lua/definition/poptracker.lua
@@ -83,6 +83,12 @@ function Tracker:UiHint(name, value) end
 ---@type boolean
 Tracker.BulkUpdate = false
 
+---Allow to evaluate logic rules fewer times than items are updated.
+---Only available in PopTracker, since 0.27.1.
+---Use as: `if Tracker.AllowDeferredLogicUpdate == false then Tracker.AllowDeferredLogicUpdate = true end`
+---@type boolean
+Tracker.AllowDeferredLogicUpdate = false
+
 
 ---- ScriptHost ----
 

--- a/doc/PACKS.md
+++ b/doc/PACKS.md
@@ -110,6 +110,7 @@ The following interfaces are provided:
 * `mixed :FindObjectForCode(string)`: returns items for `code` or location section for `@location/section`
 * `void :UiHint(name, value)`: sends a hint to the Ui, see [Ui Hints](#ui-hints). Only available in PopTracker, since 0.11.0
 * `bool .BulkUpdate`: can be set to true from Lua to pause running logic rules.
+* `bool .AllowDeferredLogicUpdate`: can be set to true from Lua to allow evaluating logic rules fewer times than items are updated.
 
 
 ### global ScriptHost

--- a/src/core/baseitem.h
+++ b/src/core/baseitem.h
@@ -64,7 +64,7 @@ protected:
     std::string _id;
     std::string _name;
     Type _type = Type::NONE;
-    std::list<std::string> _codes;
+    std::vector<std::string> _codes;
     bool _capturable = false;
     bool _loop = false;
     bool _allowDisabled = false;
@@ -122,9 +122,10 @@ public:
     }
     
     
-    virtual int providesCode(const std::string code) const { // FIXME: make this pure?
-        if (_count && canProvideCode(code)) return _count;
-        return (_stage1 && canProvideCode(code));
+    virtual int providesCode(const std::string& code) const { // FIXME: make this pure?
+        if (_count && canProvideCode(code))
+            return _count;
+        return _stage1 && canProvideCode(code);
     }
     
     virtual bool canProvideCode(const std::string& code) const { // FIXME: make this pure?

--- a/src/core/jsonitem.cpp
+++ b/src/core/jsonitem.cpp
@@ -24,7 +24,7 @@ std::string JsonItem::getCodesString() const {
     return s;
 }
 
-const std::list<std::string>& JsonItem::getCodes(int stage) const {
+const std::vector<std::string>& JsonItem::getCodes(int stage) const {
     if (_type == Type::TOGGLE) return _codes;
     if (stage>=0 && (size_t)stage<_stages.size()) return _stages[stage].getCodes();
     return _codes;
@@ -117,7 +117,15 @@ JsonItem JsonItem::FromJSON(json& j)
     item._stage2 = std::max(0,std::min(to_int(j["initial_stage_idx"],0), (int)item._stages.size()-1));
     item._count  = std::max(item._minCount, std::min(to_int(j["initial_quantity"],0), item._maxCount));
     if (item._type == Type::CONSUMABLE && item._count > 0) item._stage1=1;
-    
+
+#ifdef JSONITEM_CI_QUIRK
+    for (const auto& code : item._codes)
+        item._ciAllCodes.emplace(toLower(code));
+    for (const auto& stage : item._stages)
+        for (const auto& code : stage.getCodes())
+            item._ciAllCodes.emplace(toLower(code));
+#endif
+
     return item;
 }
 

--- a/src/core/jsonutil.h
+++ b/src/core/jsonutil.h
@@ -36,7 +36,8 @@ static nlohmann::json parse_jsonc(std::string& s)
     return j;
 }
 
-static void commasplit(const std::string& s, std::list<std::string>& l)
+template <template <class> class T>
+static void commasplit(const std::string& s, T<std::string>& l)
 {
     auto sta = s.find_first_not_of(' '); // ltrim
     auto end = s.find(',');
@@ -55,17 +56,19 @@ static void commasplit(const std::string& s, std::list<std::string>& l)
         l.push_back(s.substr(sta, end - sta));
 }
 
-static std::list<std::string> commasplit(const std::string& s)
+template <template <class> class T = std::list>
+static T<std::string> commasplit(const std::string& s)
 {
-    std::list<std::string> lst;
-    commasplit(s, lst);
+    T<std::string> lst;
+    commasplit<T>(s, lst);
     return lst;
 }
 
-static std::list<std::string> commasplit(std::string&& s)
+template <template <class> class T = std::list>
+static T<std::string> commasplit(std::string&& s)
 {
     std::string tmp = s;
-    return commasplit(tmp);
+    return commasplit<T>(tmp);
 }
 
 

--- a/src/core/jsonutil.h
+++ b/src/core/jsonutil.h
@@ -36,8 +36,8 @@ static nlohmann::json parse_jsonc(std::string& s)
     return j;
 }
 
-template <template <class> class T>
-static void commasplit(const std::string& s, T<std::string>& l)
+template <template <typename...> class T>
+void commasplit(const std::string& s, T<std::string>& l)
 {
     auto sta = s.find_first_not_of(' '); // ltrim
     auto end = s.find(',');
@@ -56,7 +56,7 @@ static void commasplit(const std::string& s, T<std::string>& l)
         l.push_back(s.substr(sta, end - sta));
 }
 
-template <template <class> class T = std::list>
+template <template <typename...> class T>
 static T<std::string> commasplit(const std::string& s)
 {
     T<std::string> lst;
@@ -64,7 +64,7 @@ static T<std::string> commasplit(const std::string& s)
     return lst;
 }
 
-template <template <class> class T = std::list>
+template <template <typename...> class T>
 static T<std::string> commasplit(std::string&& s)
 {
     std::string tmp = s;

--- a/src/core/luaitem.cpp
+++ b/src/core/luaitem.cpp
@@ -122,7 +122,7 @@ bool LuaItem::Lua_NewIndex(lua_State *L, const char *key) {
     } else if (strcmp(key,"IconMods")==0) {
         // NOTE: these are applied on top of .Icon ImageReference
         std::string s = luaL_checkstring(L,-1);
-        auto mods = commasplit(s);
+        auto mods = commasplit<std::list>(s);
         if (_extraImgMods != mods) {
             _extraImgMods = mods;
             parseFullImg();
@@ -353,7 +353,7 @@ void LuaItem::parseFullImg()
         _imgMods = _extraImgMods;
     } else {
         _img = _fullImg.substr(0, pos);
-        _imgMods = commasplit(_fullImg.substr(pos + 1));
+        _imgMods = commasplit<std::list>(_fullImg.substr(pos + 1));
         _imgMods.insert(_imgMods.end(), _extraImgMods.begin(), _extraImgMods.end());
     }
 }

--- a/src/core/luaitem.cpp
+++ b/src/core/luaitem.cpp
@@ -188,7 +188,7 @@ bool LuaItem::canProvideCode(const std::string& code) const
     return res;
 }
 
-int LuaItem::providesCode(const std::string code) const
+int LuaItem::providesCode(const std::string& code) const
 {
     if (!_providesCodeFunc.valid()) return false;
     lua_rawgeti(_L, LUA_REGISTRYINDEX, _providesCodeFunc.ref);

--- a/src/core/luaitem.h
+++ b/src/core/luaitem.h
@@ -20,7 +20,7 @@ public:
     LuaVariant Get(const char* key);
     
     virtual bool canProvideCode(const std::string& code) const override;
-    virtual int providesCode(const std::string code) const override;
+    int providesCode(const std::string& code) const override;
     virtual bool changeState(Action action) override;
     
     virtual void SetOverlay(const char* text) override {

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -474,8 +474,11 @@ done:
 Tracker::Object Tracker::FindObjectForCode(const char* code)
 {
     const auto it = _objectCache.find(std::string_view(code));
-    if (it != _objectCache.end())
+    if (it != _objectCache.end()) {
+        if (*code == '@')
+            _isIndirectConnection = true; // if called during rule resolution, this skips the cache
         return it->second;
+    }
     if (*code == '@') { // location section
         const char *start = code+1;
         const char *t = strrchr(start, '/');

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -121,6 +121,7 @@ protected:
     std::map<std::string, AccessibilityLevel> _accessibilityCache;
     std::map<std::string, bool> _visibilityCache;
     std::map<std::string, int> _providerCountCache;
+    std::map<const std::string, Object, std::less<>> _objectCache;
     std::list<std::string> _bulkItemUpdates;
     std::list<std::string> _bulkItemDisplayUpdates;
     bool _bulkUpdate = false;

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -77,7 +77,8 @@ public:
     Signal<const std::string&> onStateChanged;
     Signal<const std::string&> onDisplayChanged; // changed display of an item
     Signal<const std::string&, const std::string&> onUiHint;
-    
+    Signal<> onBulkUpdateDone;
+
     const LayoutNode& getLayout(const std::string& name) const;
     bool hasLayout(const std::string& name) const;
     const BaseItem& getItemByCode(const std::string& code) const;
@@ -100,6 +101,9 @@ public:
     AccessibilityLevel isReachable(const LocationSection& location);
     bool isVisible(const Location& location);
     bool isVisible(const Location::MapLocation& mapLoc);
+
+    bool isBulkUpdate() const;
+    bool allowDeferredLogicUpdate() const;
 
     const Pack* getPack() const;
 
@@ -125,6 +129,7 @@ protected:
     std::list<std::string> _bulkItemUpdates;
     std::list<std::string> _bulkItemDisplayUpdates;
     bool _bulkUpdate = false;
+    bool _allowDeferredLogicUpdate = false; /// opt-in flag to use onBulkUpdate to update state just once at the end
     bool _accessibilityStale = false;
     bool _visibilityStale = false;
     bool _isIndirectConnection = false; /// flag to skip cache for codes that depend on locations

--- a/src/ui/trackerview.cpp
+++ b/src/ui/trackerview.cpp
@@ -173,7 +173,7 @@ Item* TrackerView::makeItem(int x, int y, int width, int height, const ::BaseIte
                 f = img;
             } else {
                 f = img.substr(0, p);
-                filters = imageModsToFilters(_tracker, commasplit(img.substr(p + 1)));
+                filters = imageModsToFilters(_tracker, commasplit<std::list>(img.substr(p + 1)));
             }
             std::string s;
             _tracker->getPack()->ReadFile(f, s);
@@ -448,7 +448,7 @@ void TrackerView::updateDisplay(const std::string& itemid)
                 f = img;
             } else {
                 f = img.substr(0, p);
-                filters = imageModsToFilters(_tracker, commasplit(img.substr(p + 1)));
+                filters = imageModsToFilters(_tracker, commasplit<std::list>(img.substr(p + 1)));
             }
             std::string s;
             _tracker->getPack()->ReadFile(f, s);

--- a/src/ui/trackerview.cpp
+++ b/src/ui/trackerview.cpp
@@ -253,6 +253,10 @@ TrackerView::TrackerView(int x, int y, int w, int h, Tracker* tracker, const std
     _tracker->onDisplayChanged += {this, [this](void *s, const std::string& check) {
         updateDisplay(check);
     }};
+    _tracker->onBulkUpdateDone += { this, [this](void *s) {
+        if (_tracker->allowDeferredLogicUpdate())
+            updateLocations();
+    }};
     _tracker->onLocationSectionChanged += {this, [this](void *s, const LocationSection& sec) {
         updateLocation(sec.getParentID());
         for (const auto& pair: _tracker->getReferencingSections(sec))
@@ -268,6 +272,7 @@ TrackerView::~TrackerView()
     _tracker->onLayoutChanged -= this;
     _tracker->onStateChanged -= this;
     _tracker->onDisplayChanged -= this;
+    _tracker->onBulkUpdateDone -= this;
     _tracker->onLocationSectionChanged -= this;
     _tracker->onUiHint -= this;
     _tracker = nullptr;
@@ -524,7 +529,8 @@ void TrackerView::updateState(const std::string& itemid)
     for (auto w: _items[itemid]) {
         updateItem(w, item);
     }
-    updateLocations();
+    if (!_tracker->isBulkUpdate() || !_tracker->allowDeferredLogicUpdate())
+        updateLocations();
 }
 
 size_t TrackerView::addLayoutNodes(Container* container, const std::list<LayoutNode>& nodes, size_t depth)

--- a/test/core/test_jsonitem_provides.cpp
+++ b/test/core/test_jsonitem_provides.cpp
@@ -1,0 +1,235 @@
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+#include "../../src/core/jsonitem.h"
+
+using namespace std;
+using nlohmann::json;
+
+
+static auto jStatic = R"(
+{
+    "name": "item",
+    "type": "static",
+    "codes": "Code"
+}
+)"_json;
+
+TEST(JsonItemProvidesTest, StaticCanProvideCode) {
+    auto item = JsonItem::FromJSON(jStatic);
+    EXPECT_TRUE(item.canProvideCode("Code"));
+    EXPECT_FALSE(item.canProvideCode("Not"));
+}
+
+#ifdef JSONITEM_CI_QUIRK
+TEST(JsonItemProvidesTest, StaticCanProvideCodeCI) {
+    auto item = JsonItem::FromJSON(jStatic);
+    EXPECT_TRUE(item.canProvideCode("codE"));
+    EXPECT_TRUE(item.canProvideCodeLower("code"));
+    EXPECT_FALSE(item.canProvideCodeLower("not"));
+}
+#endif
+
+TEST(JsonItemProvidesTest, StaticProvidesCode) {
+    auto item = JsonItem::FromJSON(jStatic);
+    EXPECT_EQ(item.providesCode("Code"), 1);
+    EXPECT_EQ(item.providesCode("Not"), 0);
+
+    #if 0  // FIXME: we CAN currently force static to off using setState
+    item.setState(0);
+    EXPECT_EQ(item.providesCode("Code"), 1);
+    EXPECT_EQ(item.providesCode("Not"), 0);
+    #endif
+
+    item.changeState(BaseItem::Action::Toggle);
+    EXPECT_EQ(item.providesCode("Code"), 1);
+    EXPECT_EQ(item.providesCode("Not"), 0);
+    item.changeState(BaseItem::Action::Toggle);
+    EXPECT_EQ(item.providesCode("Code"), 1);
+    EXPECT_EQ(item.providesCode("Not"), 0);
+}
+
+#ifdef JSONITEM_CI_QUIRK
+TEST(JsonItemProvidesTest, StaticProvidesCodeCI) {
+    auto item = JsonItem::FromJSON(jStatic);
+    EXPECT_EQ(item.providesCode("codE"), 1);
+    EXPECT_EQ(item.providesCodeLower("code"), 1);
+}
+#endif
+
+static auto jToggle = R"(
+{
+    "name": "item",
+    "type": "toggle",
+    "codes": "code1,CODE2"
+}
+)"_json;
+
+TEST(JsonItemProvidesTest, ToggleCanProvideCode) {
+    auto item = JsonItem::FromJSON(jToggle);
+    EXPECT_TRUE(item.canProvideCode("code1"));
+    EXPECT_TRUE(item.canProvideCode("CODE2"));
+    EXPECT_FALSE(item.canProvideCode("code3"));
+}
+
+#ifdef JSONITEM_CI_QUIRK
+TEST(JsonItemProvidesTest, ToggleCanProvideCodeCI) {
+    auto item = JsonItem::FromJSON(jToggle);
+    EXPECT_TRUE(item.canProvideCode("CODE1"));
+    EXPECT_TRUE(item.canProvideCode("code2"));
+    EXPECT_TRUE(item.canProvideCodeLower("code1"));
+    EXPECT_TRUE(item.canProvideCodeLower("code2"));
+}
+#endif
+
+TEST(JsonItemProvidesTest, ToggleProvidesCode) {
+    auto item = JsonItem::FromJSON(jToggle);
+    EXPECT_EQ(item.providesCode("code1"), 0);
+    EXPECT_EQ(item.providesCode("CODE2"), 0);
+    EXPECT_EQ(item.providesCode("code3"), 0);
+    item.setState(1);
+    EXPECT_EQ(item.providesCode("code1"), 1);
+    EXPECT_EQ(item.providesCode("CODE2"), 1);
+    EXPECT_EQ(item.providesCode("code3"), 0);
+}
+
+#ifdef JSONITEM_CI_QUIRK
+TEST(JsonItemProvidesTest, ToggleProvidesCodeCI) {
+    auto item = JsonItem::FromJSON(jToggle);
+    EXPECT_EQ(item.providesCode("CODE1"), 0);
+    EXPECT_EQ(item.providesCode("code2"), 0);
+    EXPECT_EQ(item.providesCodeLower("code2"), 0);
+    item.setState(1);
+    EXPECT_EQ(item.providesCode("CODE1"), 1);
+    EXPECT_EQ(item.providesCode("code2"), 1);
+    EXPECT_EQ(item.providesCodeLower("code2"), 1);
+}
+#endif
+
+static auto jStagedSeparate = R"(
+{
+    "name": "item",
+    "type": "staged",
+    "codes": "Base",
+    "stages": [
+        {
+            "inherit_codes": false,
+            "codes": "Stage1"
+        },
+        {
+            "inherit_codes": false,
+            "codes": "Stage2"
+        }
+    ]
+}
+)"_json;
+
+TEST(JsonItemProvidesTest, StagedCanProvideCode) {
+    // NOTE: currently Base works for canProvide so it can be used to FindObjectForCode; change this?
+    auto item = JsonItem::FromJSON(jStagedSeparate);
+    EXPECT_TRUE(item.canProvideCode("Base"));
+    EXPECT_TRUE(item.canProvideCode("Stage1"));
+    EXPECT_TRUE(item.canProvideCode("Stage2"));
+    EXPECT_FALSE(item.canProvideCode("Not"));
+}
+
+#ifdef JSONITEM_CI_QUIRK
+TEST(JsonItemProvidesTest, StagedCanProvideCodeCI) {
+    // NOTE: currently Base works for canProvide so it can be used to FindObjectForCode; change this?
+    auto item = JsonItem::FromJSON(jStagedSeparate);
+    EXPECT_TRUE(item.canProvideCode("BASE"));
+    EXPECT_TRUE(item.canProvideCode("STAGE1"));
+    EXPECT_TRUE(item.canProvideCodeLower("stage2"));
+    EXPECT_FALSE(item.canProvideCodeLower("not"));
+}
+#endif
+
+TEST(JsonItemProvidesTest, StagedProvidesCode) {
+    // NOTE: currently Base is never provided for staged because it's not really valid for staged; change this?
+    auto item = JsonItem::FromJSON(jStagedSeparate);
+    EXPECT_EQ(item.providesCode("Base"), 0);
+    EXPECT_EQ(item.providesCode("Stage1"), 0);
+    EXPECT_EQ(item.providesCode("Stage2"), 0);
+    item.setState(1, -1);
+    EXPECT_EQ(item.providesCode("Base"), 0);
+    EXPECT_EQ(item.providesCode("Stage1"), 1);
+    EXPECT_EQ(item.providesCode("Stage2"), 0);
+    item.setState(1, 1);
+    EXPECT_EQ(item.providesCode("Base"), 0);
+    EXPECT_EQ(item.providesCode("Stage1"), 0);
+    EXPECT_EQ(item.providesCode("Stage2"), 1);
+}
+
+#ifdef JSONITEM_CI_QUIRK
+TEST(JsonItemProvidesTest, StagedProvidesCodeCI) {
+    auto item = JsonItem::FromJSON(jStagedSeparate);
+    item.setState(1, 0);
+    EXPECT_EQ(item.providesCode("STAGE1"), 1);
+    EXPECT_EQ(item.providesCodeLower("stage1"), 1);
+    item.setState(1, 1);
+    EXPECT_EQ(item.providesCode("STAGE1"), 0);
+    EXPECT_EQ(item.providesCodeLower("stage1"), 0);
+}
+#endif
+
+static auto jStagedInherits = R"(
+{
+    "name": "item",
+    "type": "staged",
+    "codes": "Base",
+    "stages": [
+        {
+            "inherit_codes": true,
+            "codes": "Stage1"
+        },
+        {
+            "inherit_codes": true,
+            "codes": "Stage2"
+        }
+    ]
+}
+)"_json;
+
+TEST(JsonItemProvidesTest, StagedInheritsCanProvideCode) {
+    // NOTE: currently Base works for canProvide so it can be used to FindObjectForCode; change this?
+    auto item = JsonItem::FromJSON(jStagedInherits);
+    EXPECT_TRUE(item.canProvideCode("Base"));
+    EXPECT_TRUE(item.canProvideCode("Stage1"));
+    EXPECT_TRUE(item.canProvideCode("Stage2"));
+    EXPECT_FALSE(item.canProvideCode("Not"));
+}
+
+#ifdef JSONITEM_CI_QUIRK
+TEST(JsonItemProvidesTest, StagedInheritsCanProvideCodeCI) {
+    // NOTE: currently Base works for canProvide so it can be used to FindObjectForCode; change this?
+    auto item = JsonItem::FromJSON(jStagedInherits);
+    EXPECT_TRUE(item.canProvideCode("BASE"));
+    EXPECT_TRUE(item.canProvideCode("STAGE1"));
+    EXPECT_TRUE(item.canProvideCodeLower("stage2"));
+    EXPECT_FALSE(item.canProvideCodeLower("not"));
+}
+#endif
+
+TEST(JsonItemProvidesTest, StagedInheritsProvidesCode) {
+    // NOTE: currently Base is never provided for staged because it's not really valid for staged; change this?
+    auto item = JsonItem::FromJSON(jStagedInherits);
+    EXPECT_EQ(item.providesCode("Base"), 0);
+    EXPECT_EQ(item.providesCode("Stage1"), 0);
+    EXPECT_EQ(item.providesCode("Stage2"), 0);
+    item.setState(1, -1);
+    EXPECT_EQ(item.providesCode("Base"), 0);
+    EXPECT_EQ(item.providesCode("Stage1"), 1);
+    EXPECT_EQ(item.providesCode("Stage2"), 0);
+    item.setState(1, 1);
+    EXPECT_EQ(item.providesCode("Base"), 0);
+    EXPECT_EQ(item.providesCode("Stage1"), 1);
+    EXPECT_EQ(item.providesCode("Stage2"), 1);
+}
+
+#ifdef JSONITEM_CI_QUIRK
+TEST(JsonItemProvidesTest, StagedInheritsProvidesCodeCI) {
+    auto item = JsonItem::FromJSON(jStagedInherits);
+    item.setState(1, 0);
+    EXPECT_EQ(item.providesCode("STAGE1"), 1);
+    EXPECT_EQ(item.providesCodeLower("stage1"), 1);
+}
+#endif

--- a/test/jsonutil/test_commasplit.cpp
+++ b/test/jsonutil/test_commasplit.cpp
@@ -11,30 +11,30 @@ using namespace std;
 // only trailing empty fields should be dropped
 
 TEST(CommaSplitTest, Empty) {
-    EXPECT_EQ(commasplit(""),
+    EXPECT_EQ(commasplit<list>(""),
               list<string>({}));
 }
 
 TEST(CommaSplitTest, TrailingComma) {
     // Trailing empty values should be dropped
-    EXPECT_EQ(commasplit("a,"),
+    EXPECT_EQ(commasplit<list>("a,"),
               list<string>({"a"}));
 }
 
 TEST(CommaSplitTest, LeadingEmpty) {
     // Leading empty values should be kept
-    EXPECT_EQ(commasplit(",b"),
+    EXPECT_EQ(commasplit<list>(",b"),
               list<string>({"", "b"}));
 }
 
 TEST(CommaSplitTest, MiddleEmpty) {
     // Empty values in the middle should be kept
-    EXPECT_EQ(commasplit("a,,b"),
+    EXPECT_EQ(commasplit<list>("a,,b"),
               list<string>({"a", "", "b"}));
 }
 
 TEST(CommaSplitTest, TrailingWhitespace) {
     // If trailing whitespace results in trailing comma, it should behave the same as TrailingComma
-    EXPECT_EQ(commasplit("a, "),
+    EXPECT_EQ(commasplit<list>("a, "),
               list<string>({"a"}));
 }


### PR DESCRIPTION
Not all code comparisons were case-insensitive (CI). Also adds tests, primarily for CI.
Introduces an object cache that could change behaviour in some packs but shouldn't.
Replaces list<> by vector<> for code and adds an extra set that contains all lower case codes for faster checking.

Testing if vector<> for _ciAllCodes would be better was not done yet (TODO).

Allows to opt into deferred logic updates via
```lua
if Tracker.AllowDefferedLogicUpdate == false then
     Tracker.AllowDefferedLogicUpdate = true
end
```
to run fewer logic updates (currently only uses when switching from bulk update back to normal update).