### PR TITLE
Build: include schema and api on all targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,6 +289,7 @@ $(WIN32_ZIP) $(WIN64_ZIP):
 	rm -rf $(TMP_DIR)
 	mkdir -p $(TMP_DIR)/poptracker/packs
 	cp -r api $(TMP_DIR)/poptracker/
+	cp -r schema $(TMP_DIR)/poptracker/
 	cp -r assets $(TMP_DIR)/poptracker/
 	cp LICENSE README.md CHANGELOG.md CREDITS.md $(TMP_DIR)/poptracker/
 	cp $(dir $<)*.exe $(TMP_DIR)/poptracker/
@@ -322,6 +323,7 @@ $(NIX_XZ): $(NIX_EXE) | $(DIST_DIR)
 	rm -rf $(TMP_DIR)
 	mkdir -p $(TMP_DIR)/poptracker/packs
 	cp -r api $(TMP_DIR)/poptracker/
+	cp -r schema $(TMP_DIR)/poptracker/
 	cp -r assets $(TMP_DIR)/poptracker/
 	cp LICENSE README.md CHANGELOG.md CREDITS.md $(TMP_DIR)/poptracker/
 	cp $(NIX_EXE) $(TMP_DIR)/poptracker/

--- a/linux/AppImageBuilder.yml
+++ b/linux/AppImageBuilder.yml
@@ -131,3 +131,7 @@ script: |
   install -D "assets/icon.png" "$TARGET_APPDIR/usr/share/icons/poptracker.png"
 
   cp -r assets "$TARGET_APPDIR/usr/bin/."
+
+  mkdir -p "$TARGET_APPDIR/usr/share/poptracker"
+  cp -r api schema "$TARGET_APPDIR/usr/share/poptracker/."
+  rm "$TARGET_APPDIR/usr/share/poptracker/"*/README.md

--- a/macosx/bundle_macosx_app.sh
+++ b/macosx/bundle_macosx_app.sh
@@ -72,6 +72,8 @@ DST_DIR=`dirname $EXE`
 
 ROOT_DIR="$SRC_DIR/.."
 SRC_ASSETS_DIR="$ROOT_DIR/assets"
+SRC_API_DIR="$ROOT_DIR/api"
+SRC_SCHEMA_DIR="$ROOT_DIR/schema"
 DOCS="$ROOT_DIR/LICENSE $ROOT_DIR/README.md $ROOT_DIR/CHANGELOG.md $ROOT_DIR/CREDITS.md"
 
 APP_BUNDLE_DIR="$DST_DIR/$BUNDLE_NAME.app"
@@ -128,6 +130,11 @@ cp $ICON $DST_ICON
 cp $EXE $DST_EXE
 cp -r $SRC_ASSETS_DIR $APP_BUNDLE_MACOS_DIR
 cp -r $DOCS $APP_BUNDLE_MACOS_DIR
+
+# Copy schema and api into app bundle
+cp -r "$SRC_API_DIR" "$APP_BUNDLE_RESOURCES_DIR"
+cp -r "$SRC_SCHEMA_DIR" "$APP_BUNDLE_RESOURCES_DIR"
+rm "$APP_BUNDLE_RESOURCES_DIR/"*/README.md
 
 # Build third party libraries and update dynamic paths
 # This won't work with libraries installed with brew.
@@ -212,4 +219,3 @@ install_name_tool -change $OLD_LIB_SDL2_IMAGE @executable_path/../Frameworks/$LI
 install_name_tool -change $OLD_LIB_SDL2_TTF @executable_path/../Frameworks/$LIB_SDL2_TTF $DST_EXE
 install_name_tool -change $OLD_LIB_OPENSSL @executable_path/../Frameworks/$LIB_OPENSSL $DST_EXE
 install_name_tool -change $OLD_LIB_CRYPTO @executable_path/../Frameworks/$LIB_CRYPTO $DST_EXE
-


### PR DESCRIPTION
* add schema to Windows dist zip - includes README.md since that is visible to the user
* add schema to the Ubuntu dist tar - includes README.md since that is visible to the user
* add schema and api to the AppImage/usr/share/poptracker/ - without README, since /usr/share is data files only
* add schema and api to the macos app bundle - without README, since Resources is data files only and not visible to the user