### PR TITLE
CI: Downgrade svt-av1

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -125,6 +125,12 @@ jobs:
           mingw64/mingw-w64-x86_64-openssl
           mingw64/mingw-w64-x86_64-gtest
           p7zip
+    - name: Fix dependencies
+      shell: msys2 {0}
+      run: |
+        # static svt-av1 2.3.0-1 lib seems to be currently broken
+        wget https://quantum-mirror.hu/mirrors/pub/msys2/mingw/mingw64/mingw-w64-x86_64-svt-av1-2.2.1-1-any.pkg.tar.zst
+        pacman -U --noconfirm mingw-w64-x86_64-svt-av1-2.2.1-1-any.pkg.tar.zst
     - uses: actions/checkout@v4
       with:
         submodules: recursive

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,6 +70,12 @@ jobs:
           mingw64/mingw-w64-x86_64-openssl
           mingw64/mingw-w64-x86_64-gtest
           p7zip
+    - name: Fix dependencies (msys2)
+      if: ${{ startsWith(matrix.os, 'windows') }}
+      run: |
+        # static svt-av1 2.3.0-1 lib seems to be currently broken
+        wget https://quantum-mirror.hu/mirrors/pub/msys2/mingw/mingw64/mingw-w64-x86_64-svt-av1-2.2.1-1-any.pkg.tar.zst
+        pacman -U --noconfirm mingw-w64-x86_64-svt-av1-2.2.1-1-any.pkg.tar.zst
     - uses: actions/checkout@v4
       with:
         submodules: recursive


### PR DESCRIPTION
The msys2 .a file for svt-av1 2.3.0 seems to be currently broken. This downgrades svt-av1 back to the previous version.

Long-term fix is probably to build libsdl2_image as part of make on Windows since the dependencies are crazy already.