### PR TITLE
Fix memory watches triggering when non-memory AT-backend connects

### DIFF
--- a/src/core/autotracker.h
+++ b/src/core/autotracker.h
@@ -178,9 +178,13 @@ public:
         return State::Unavailable;
     }
 
-    bool isAnyConnected()
+    bool isAnyMemoryConnected()
     {
         for (int index = 0; index < (int)_state.size(); ++index) {
+            if (_ap && _backendIndex[_ap] == index)
+                continue; // AP doesn't have memory
+            if (_uat && _backendIndex[_uat] == index)
+                continue; // UAT doesn't have memory
             if (getState(index) >= State::ConsoleConnected)
                 return true;
         }

--- a/src/core/scripthost.cpp
+++ b/src/core/scripthost.cpp
@@ -561,7 +561,7 @@ void ScriptHost::resetWatches()
 
 void ScriptHost::runMemoryWatchCallbacks()
 {
-    if (!_autoTracker || !_autoTracker->isAnyConnected())
+    if (!_autoTracker || !_autoTracker->isAnyMemoryConnected())
         return;
 
     // we need to run callbacks because the autotracker changed some cache


### PR DESCRIPTION
https://discord.com/channels/937157230963339364/1171232344468901979/threads/1319421688064245851