### PR TITLE
Windows: add manifest file to re-enable visual styles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -403,9 +403,12 @@ $(WIN64_BUILD_DIR)/liblua.a: lib/lua/makefile lib/lua/luaconf.h | $(WIN64_BUILD_
 	mv $(WIN64_BUILD_DIR)/lib/lua/$(notdir $@) $@
 	rm -rf $(WIN64_BUILD_DIR)/lib/lua
 
-$(WIN32_BUILD_DIR)/app.res: $(SRC_DIR)/app.rc $(SRC_DIR)/version.h assets/icon.ico | $(WIN32_BUILD_DIR)
+$(BUILD_DIR)/poptracker.exe.manifest: win32/exe.manifest.template.xml | $(BUILD_DIR)
+	sed 's/{{VERSION}}/$(VERSION).0/g;s/{{NAME}}/poptracker/g;s/{{DESCRIPTION}}/PopTracker/g' $< > $@
+
+$(WIN32_BUILD_DIR)/app.res: $(SRC_DIR)/app.rc $(SRC_DIR)/version.h assets/icon.ico $(BUILD_DIR)/poptracker.exe.manifest | $(WIN32_BUILD_DIR)
 	$(WIN32WINDRES) $(WINDRES_FLAGS) $< -O coff $@
-$(WIN64_BUILD_DIR)/app.res: $(SRC_DIR)/app.rc $(SRC_DIR)/version.h assets/icon.ico | $(WIN64_BUILD_DIR)
+$(WIN64_BUILD_DIR)/app.res: $(SRC_DIR)/app.rc $(SRC_DIR)/version.h assets/icon.ico $(BUILD_DIR)/poptracker.exe.manifest | $(WIN64_BUILD_DIR)
 	$(WIN64WINDRES) $(WINDRES_FLAGS) $< -O coff $@
 
 # Build dirs

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,8 @@ WIN64_INCLUDE_DIRS = -Iwin32-lib/x86_64/include
 WIN64_LIB_DIRS = -L./win32-lib/x86_64/bin -L./win32-lib/x86_64/lib
 SSL_LIBS = -lssl -lcrypto
 NIX_LIBS = -lSDL2_ttf -lSDL2_image $(SSL_LIBS)
-WIN32_LIBS = -lmingw32 -lSDL2main -lSDL2 -mwindows -lSDL2_image -lSDL2_ttf $(SSL_LIBS) -lm -lz -lwsock32 -lws2_32 -ldinput8 -ldxguid -ldxerr8 -luser32 -lusp10 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lversion -lhid -lsetupapi -lfreetype -lbz2 -lpng -luuid -lrpcrt4 -lcrypt32 -lssp -lcrypt32 -static-libgcc
-WIN64_LIBS = -lmingw32 -lSDL2main -lSDL2 -mwindows -Wl,--no-undefined -Wl,--dynamicbase -Wl,--nxcompat -lSDL2_image -lSDL2_ttf $(SSL_LIBS) -lm -lz -lwsock32 -lws2_32 -ldinput8 -ldxguid -ldxerr8 -luser32 -lusp10 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lversion -lhid -lsetupapi -lfreetype -lbz2 -lpng -luuid -lrpcrt4 -lcrypt32 -lssp -lcrypt32 -static-libgcc -Wl,--high-entropy-va
+WIN32_LIBS = -D_WIN32_WINNT=0x0502 -lmingw32 -lSDL2main -lSDL2 -mwindows -lSDL2_image -lSDL2_ttf $(SSL_LIBS) -lm -lz -lwsock32 -lws2_32 -ldinput8 -ldxguid -ldxerr8 -luser32 -lusp10 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lversion -lhid -lsetupapi -lfreetype -lbz2 -lpng -luuid -lrpcrt4 -lcrypt32 -lssp -lcrypt32 -static-libgcc
+WIN64_LIBS = -D_WIN32_WINNT=0x0502 -lmingw32 -lSDL2main -lSDL2 -mwindows -Wl,--no-undefined -Wl,--dynamicbase -Wl,--nxcompat -lSDL2_image -lSDL2_ttf $(SSL_LIBS) -lm -lz -lwsock32 -lws2_32 -ldinput8 -ldxguid -ldxerr8 -luser32 -lusp10 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lversion -lhid -lsetupapi -lfreetype -lbz2 -lpng -luuid -lrpcrt4 -lcrypt32 -lssp -lcrypt32 -static-libgcc -Wl,--high-entropy-va
 
 # extract version
 VERSION_MAJOR := $(shell grep '.define APP_VERSION_MAJOR' $(SRC_DIR)/version.h | rev | cut -d' ' -f 1 | rev )

--- a/src/app.rc
+++ b/src/app.rc
@@ -8,6 +8,7 @@
 #endif
 
 id ICON "../assets/icon.ico"
+1 24 "../build/poptracker.exe.manifest"
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     APP_VERSION_TUPLE

--- a/src/app.rc
+++ b/src/app.rc
@@ -7,6 +7,8 @@
 #define APP_FILE_FLAGS VS_FF_DEBUG
 #endif
 
+LANGUAGE 0,0 // neutral
+
 id ICON "../assets/icon.ico"
 1 24 "../build/poptracker.exe.manifest"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,24 +7,9 @@
 
 #include <windows.h>
 
-// as per https://stackoverflow.com/questions/4308503
-ULONG_PTR EnableVisualStyles(VOID)
+void EnableVisualStyles(void)
 {
-    TCHAR dir[MAX_PATH];
-    ULONG_PTR ulpActivationCookie = FALSE;
-    ACTCTX actCtx =
-    {
-        sizeof(actCtx),
-        ACTCTX_FLAG_RESOURCE_NAME_VALID
-            | ACTCTX_FLAG_SET_PROCESS_DEFAULT
-            | ACTCTX_FLAG_ASSEMBLY_DIRECTORY_VALID,
-        TEXT("shell32.dll"), 0, 0, dir, (LPCTSTR)124
-    };
-    UINT cch = GetSystemDirectory(dir, sizeof(dir) / sizeof(*dir));
-    if (cch >= sizeof(dir) / sizeof(*dir)) { return FALSE; /*shouldn't happen*/ }
-    dir[cch] = TEXT('\0');
-    ActivateActCtx(CreateActCtx(&actCtx), &ulpActivationCookie);
-    return ulpActivationCookie;
+    // done via manifest now
 }
 
 #define getche _getwche

--- a/win32/exe.manifest.template.xml
+++ b/win32/exe.manifest.template.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+	<assemblyIdentity version="{{VERSION}}" processorArchitecture="*" name="{{NAME}}" type="win32" />
+	<description>{{DESCRIPTION}}</description>
+	<dependency>
+		<dependentAssembly>
+			<assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*" />
+		</dependentAssembly>
+	</dependency>
+</assembly>


### PR DESCRIPTION
Fixes https://discord.com/channels/937157230963339364/1323959597534285955

Msys2 added a default manifest resource that does not enable visual styles and that superseded our hack.
We now add our own resource that overrides the msys2 one, which also makes the hack obsolete.

Note: The internet claims that `RT_MANIFEST` should be 24, but when I tried `1 RT_MANIFEST ...` instead of `1 24 ...`, I ended up with a different entry in the .res.

We also set the windows version now to avoid some warnings; turns out we don't actually need to call into comdlg32, so neither neither `_WIN32_WINNT` nor `_WIN32_IE` is technically needed, but kept WINNT to get rid of the warnings.

(If we ever need to call stuff like InitCommonControlsEx, we should define WINNT to >=0x0600 and IE to >=0x0300)

We also now set the resource LANGUAGE to neutral, which makes more sense for the manifest and icon and should not influence the StringFileInfo block because that has its own Translation info.