### PR TITLE
macOS: update openssl to 3.0.16

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -76,7 +76,7 @@ jobs:
     steps:
     - name: Install dependencies
       run: |
-        brew install coreutils SDL2 sdl2_ttf sdl2_image openssl@1.1 automake libtool autoconf googletest || true
+        brew install coreutils SDL2 sdl2_ttf sdl2_image openssl@3.0 automake libtool autoconf googletest || true
     - uses: actions/checkout@v4
       with:
         submodules: recursive

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,7 +106,7 @@ jobs:
     steps:
     - name: Install dependencies
       run: |
-        brew install coreutils SDL2 sdl2_ttf sdl2_image openssl@1.1 automake libtool autoconf googletest || true
+        brew install coreutils SDL2 sdl2_ttf sdl2_image openssl@3.0 automake libtool autoconf googletest || true
     - uses: actions/checkout@v4
       with:
         submodules: recursive

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,7 +57,7 @@ jobs:
     - name: Install dependencies (brew)
       if: ${{ startsWith(matrix.os, 'macos') }}
       run: |
-        brew install coreutils SDL2 sdl2_ttf sdl2_image openssl@1.1 googletest || true
+        brew install coreutils SDL2 sdl2_ttf sdl2_image openssl@3.0 googletest || true
     - name: Install extra dependencies (brew)
       if: ${{ startsWith(matrix.os, 'macos') && contains(matrix.extra_make_args, 'MACOS_DEPLOYMENT_TARGET') }}
       run: |

--- a/BUILD.md
+++ b/BUILD.md
@@ -89,7 +89,7 @@ The build found in Releases is done with a customized sdl2, so the builds differ
 
 ## Build on macOS
 
-- run `brew install coreutils SDL2 sdl2_ttf sdl2_image openssl@1.1`
+- run `brew install coreutils SDL2 sdl2_ttf sdl2_image openssl@3.0`
 - run `make CONF=RELEASE`
 
 The build will link against brew libraries.

--- a/Makefile
+++ b/Makefile
@@ -208,10 +208,10 @@ DEPLOYMENT_TARGET_MINOR := $(shell echo $(DEPLOYMENT_TARGET) | cut -f2 -d.)
 # NOTE: on macos before 10.15 we have to use boost::filesystem instead of std::filesystem
 #       This is currently not built automatically. Please open an issue if you really need a build for macos<10.15.
 HAS_STD_FILESYSTEM := $(shell [ $(DEPLOYMENT_TARGET_MAJOR) -gt 10 -o \( $(DEPLOYMENT_TARGET_MAJOR) -eq 10 -a $(DEPLOYMENT_TARGET_MINOR) -ge 15 \) ] && echo true)
-NIX_CPP_FLAGS += -mmacosx-version-min=$(DEPLOYMENT_TARGET) -I$(BREW_PREFIX)/opt/openssl@1.1/include -I$(BREW_PREFIX)/include
-NIX_LD_FLAGS += -mmacosx-version-min=$(DEPLOYMENT_TARGET) -L$(BREW_PREFIX)/opt/openssl@1.1/lib -L$(BREW_PREFIX)/lib
-NIX_C_FLAGS += -mmacosx-version-min=$(DEPLOYMENT_TARGET) -I$(BREW_PREFIX)/opt/openssl@1.1/include -I$(BREW_PREFIX)/include
-NIX_LUA_C_FLAGS += -mmacosx-version-min=$(DEPLOYMENT_TARGET) -I$(BREW_PREFIX)/opt/openssl@1.1/include -I$(BREW_PREFIX)/include
+NIX_CPP_FLAGS += -mmacosx-version-min=$(DEPLOYMENT_TARGET) -I$(BREW_PREFIX)/opt/openssl@3.0/include -I$(BREW_PREFIX)/include
+NIX_LD_FLAGS += -mmacosx-version-min=$(DEPLOYMENT_TARGET) -L$(BREW_PREFIX)/opt/openssl@3.0/lib -L$(BREW_PREFIX)/lib
+NIX_C_FLAGS += -mmacosx-version-min=$(DEPLOYMENT_TARGET) -I$(BREW_PREFIX)/opt/openssl@3.0/include -I$(BREW_PREFIX)/include
+NIX_LUA_C_FLAGS += -mmacosx-version-min=$(DEPLOYMENT_TARGET) -I$(BREW_PREFIX)/opt/openssl@3.0/include -I$(BREW_PREFIX)/include
 else
 HAS_STD_FILESYSTEM ?= true
 endif

--- a/macosx/build_thirdparty.sh
+++ b/macosx/build_thirdparty.sh
@@ -213,7 +213,7 @@ fi
 cd $LIB_OPENSSL_DEST_DIR
 
 ./config $CONFIGURE_FLAGS
-make -j3
+make -j4
 
 [ -f $LIB_OPENSSL_TARGET ] || { echo "Missing $LIB_OPENSSL_TARGET..." ; exit 1; }
 [ -f $LIB_CRYPTO_TARGET ] || { echo "Missing $LIB_CRYPTO_TARGET..." ; exit 1; }

--- a/macosx/build_thirdparty.sh
+++ b/macosx/build_thirdparty.sh
@@ -61,15 +61,15 @@ LIB_SDL_IMAGE_TAG="release-2.8.4"
 LIB_SDL_TTF_TAG="release-2.22.0"
 LIB_PNG_TAG="v1.6.44"
 LIB_FREETYPE_TAG="VER-2-13-3"
-LIB_OPENSSL_TAG="OpenSSL_1_1_1w"
+LIB_OPENSSL_TAG="openssl-3.0.16"
 
 LIB_SDL_TARGET="build/.libs/libSDL2-2.0.0.dylib"
 LIB_SDL_IMAGE_TARGET=".libs/libSDL2_image-2.0.0.dylib"
 LIB_SDL_TTF_TARGET=".libs/libSDL2_ttf-2.0.0.dylib"
 LIB_PNG_TARGET=".libs/libpng16.16.dylib"
 LIB_FREETYPE_TARGET="objs/.libs/libfreetype.6.dylib"
-LIB_OPENSSL_TARGET="libssl.1.1.dylib"
-LIB_CRYPTO_TARGET="libcrypto.1.1.dylib"
+LIB_OPENSSL_TARGET="libssl.3.dylib"
+LIB_CRYPTO_TARGET="libcrypto.3.dylib"
 
 REGEX="s/^.*\/\([^\/]*\).git$/\1/"
 

--- a/macosx/bundle_macosx_app.sh
+++ b/macosx/bundle_macosx_app.sh
@@ -152,8 +152,8 @@ LIB_SDL2_IMAGE="libSDL2_image-2.0.0.dylib"
 LIB_SDL2_TTF="libSDL2_ttf-2.0.0.dylib"
 LIB_FREETYPE="libfreetype.6.dylib"
 LIB_PNG="libpng16.16.dylib"
-LIB_OPENSSL="libssl.1.1.dylib"
-LIB_CRYPTO="libcrypto.1.1.dylib"
+LIB_OPENSSL="libssl.3.dylib"
+LIB_CRYPTO="libcrypto.3.dylib"
 
 cp "$SRC_DIR/$LIB_DIR/$LIB_SDL2" $APP_BUNDLE_FRAMEWORKS_DIR
 cp "$SRC_DIR/$LIB_DIR/$LIB_SDL2_IMAGE" $APP_BUNDLE_FRAMEWORKS_DIR


### PR DESCRIPTION
also use more threads to speedup the build on intel runners.