### PR TITLE
Fix problems with composite_toggle and toggle_badged

### DIFF
--- a/src/core/jsonitem.cpp
+++ b/src/core/jsonitem.cpp
@@ -121,9 +121,12 @@ JsonItem JsonItem::FromJSON(json& j)
 #ifdef JSONITEM_CI_QUIRK
     for (const auto& code : item._codes)
         item._ciAllCodes.emplace(toLower(code));
-    for (const auto& stage : item._stages)
-        for (const auto& code : stage.getCodes())
-            item._ciAllCodes.emplace(toLower(code));
+    if (item._type != Type::COMPOSITE_TOGGLE) {
+        // stages can provide codes, but not for composite toggle since the stages are fake
+        for (const auto& stage : item._stages)
+            for (const auto& code : stage.getCodes())
+                item._ciAllCodes.emplace(toLower(code));
+    }
 #endif
 
     return item;

--- a/src/core/jsonitem.h
+++ b/src/core/jsonitem.h
@@ -141,6 +141,9 @@ public:
 #else
         if (std::find(_codes.begin(), _codes.end(), code) != _codes.end()) return true;
 #endif
+        if (_type == Type::COMPOSITE_TOGGLE)
+            return false; // composite toggle has fake stages we have to ignore for this
+
         for (const auto& stage: _stages)
             if (stage.hasCode(code))
                 return true;

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -202,17 +202,31 @@ bool Tracker::AddItems(const std::string& file) {
                 auto rightCodes = i->getCodes(2);
                 if (!leftCodes.empty()) {
                     auto o = FindObjectForCode(leftCodes.front().c_str());
-                    if (o.type == Object::RT::JsonItem)
-                        o.jsonItem->setState((n&1)?1:0); // TODO: advanceToCode() instead?
-                    else if (o.type == Object::RT::LuaItem)
+                    if (o.type == Object::RT::JsonItem) {
+                        if (o.jsonItem->getType() == BaseItem::Type::COMPOSITE_TOGGLE
+                                || o.jsonItem->getType() == BaseItem::Type::TOGGLE_BADGED) {
+                            fprintf(stderr, "WARNING: ignored %s as item_left of composite\n",
+                                BaseItem::Type2Str(o.jsonItem->getType()).c_str());
+                        } else {
+                            o.jsonItem->setState((n&1)?1:0); // TODO: advanceToCode() instead?
+                        }
+                    } else if (o.type == Object::RT::LuaItem) {
                         o.luaItem->setState((n&1)?1:0);
+                    }
                 }
                 if (!rightCodes.empty()) {
                     auto o = FindObjectForCode(rightCodes.front().c_str());
-                    if (o.type == Object::RT::JsonItem)
-                        o.jsonItem->setState((n&2)?1:0);
-                    else if (o.type == Object::RT::LuaItem)
+                    if (o.type == Object::RT::JsonItem) {
+                        if (o.jsonItem->getType() == JsonItem::Type::COMPOSITE_TOGGLE
+                                || o.jsonItem->getType() == BaseItem::Type::TOGGLE_BADGED) {
+                            fprintf(stderr, "WARNING: ignored %s as item_right of composite\n",
+                                BaseItem::Type2Str(o.jsonItem->getType()).c_str());
+                        } else {
+                            o.jsonItem->setState((n&2)?1:0);
+                        }
+                    } else if (o.type == Object::RT::LuaItem) {
                         o.luaItem->setState((n&2)?1:0);
+                    }
                 }
             }
             if (_bulkUpdate)

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -135,6 +135,7 @@ protected:
     bool _isIndirectConnection = false; /// flag to skip cache for codes that depend on locations
     bool _updatingCache = false; /// true while cache*() is running
     std::set<std::string> _itemChangesDuringCacheUpdate;
+    std::map<std::string, std::vector<std::string>> _missingBaseItemConnection;
 
     std::map<std::string, std::vector<std::string>> _sectionNameRefs;
     std::map<std::reference_wrapper<const LocationSection>,

--- a/src/ui/trackerview.cpp
+++ b/src/ui/trackerview.cpp
@@ -183,7 +183,8 @@ Item* TrackerView::makeItem(int x, int y, int width, int height, const ::BaseIte
 
     std::string id = origItem.getID();
     w->onClick += {this, [this,id] (void *s, int x, int y, int btn) {
-        printf("Item %s clicked w/ btn %d!\n", id.c_str(), btn);
+        printf("Item %s: \"%s\" clicked w/ btn %d!\n",
+            id.c_str(), sanitize_print(_tracker->getItemById(id).getName()).c_str(), btn);
         if (btn == BUTTON_LEFT) {
             _tracker->changeItemState(id, ::BaseItem::Action::Primary);
         } else if (btn == BUTTON_RIGHT) {


### PR DESCRIPTION
If order of definition was wrong, it would either not sync or endlessly update / crash.

This fixes the updating and also adds some safe guards to not end in the update loop.

Also prints the item name for the "click" debug message.