### PR TITLE
Fix Lua logic staleness when loading state

### DIFF
--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -1218,6 +1218,13 @@ bool Tracker::loadState(nlohmann::json& state)
             }
         }
     }
+
+    // updating sections above will evaluate stale logic for map locations
+    // make sure logic is reevaluated after updating the map locations
+    _providerCountCache.clear();
+    _accessibilityStale = true;
+    _visibilityStale = true;
+
     eraseDuplicates(_bulkItemUpdates);
     for (const auto& id: _bulkItemUpdates)
         onStateChanged.emit(this, id);


### PR DESCRIPTION
PopTracker would not notify the pack about changed codes, but cache logic results that are stale.

Test builds here: <https://github.com/black-sliver/PopTracker/actions/runs/13553712721>