### PR TITLE
Remove codes from progressive/_toggle

### DIFF
--- a/schema/packs/strict/items.json
+++ b/schema/packs/strict/items.json
@@ -215,7 +215,6 @@
                     },
                     "name": true,
                     "type": true,
-                    "codes": true,
                     "capturable": true,
                     "overlay_align": true
                 },
@@ -253,7 +252,6 @@
                     },
                     "name": true,
                     "type": true,
-                    "codes": true,
                     "capturable": true,
                     "overlay_align": true
                 },


### PR DESCRIPTION
codes directly on a progressive item do not work in other programs and also don't behave as one might expect when used as a hosted item