### PR TITLE
Fix right click on progressive item with 0 stages

### DIFF
--- a/src/core/jsonitem.cpp
+++ b/src/core/jsonitem.cpp
@@ -198,8 +198,10 @@ bool JsonItem::_changeStateImpl(BaseItem::Action action) {
         } else if (action == Action::Secondary || action == Action::Prev) {
             n--;
             if (n<0) {
-                if (_loop) n = (int)_stages.size()-1;
-                else n++;
+                if (_loop && !_stages.empty())
+                    n = (int)_stages.size() - 1;
+                else
+                    n++;
             }
         } else {
             // single button control
@@ -232,11 +234,13 @@ bool JsonItem::_changeStateImpl(BaseItem::Action action) {
             } else {
                 n--;
                 if (n<0) {
-                    if (_loop) {
-                        n = (int)_stages.size()-1;
+                    if (_loop && !_stages.empty()) {
+                        n = (int)_stages.size() - 1;
                         a = 1;
                     }
-                    else n++;
+                    else {
+                        n++;
+                    }
                 }
             }
         } else {
@@ -266,8 +270,10 @@ bool JsonItem::_changeStateImpl(BaseItem::Action action) {
         } else if (action == Action::Prev) {
             int n = _stage2-1;
             if (n<0) {
-                if (_loop) n = _stages.size()-1;
-                else n++;
+                if (_loop && !_stages.empty())
+                    n = (int)_stages.size() - 1;
+                else
+                    n++;
             }
             if (n == _stage2) return false;
             _stage2 = n;

--- a/src/core/jsonitem.h
+++ b/src/core/jsonitem.h
@@ -120,8 +120,11 @@ public:
     }
     
     virtual const std::string& getCurrentName() const override {
-        if ((int)_stages.size() > _stage2 && !_stages[_stage2].getName().empty())
-            return _stages[_stage2].getName();
+        if ((int)_stages.size() > _stage2) {
+            assert(_stage2 >= 0);
+            if (!_stages[_stage2].getName().empty())
+                return _stages[_stage2].getName();
+        }
         return _name;
     }
 

--- a/src/ui/item.cpp
+++ b/src/ui/item.cpp
@@ -1,4 +1,5 @@
 #include "item.h"
+#include <assert.h>
 #include <stdio.h>
 #include <SDL2/SDL_image.h>
 #include "../uilib/colorhelper.h"
@@ -141,6 +142,7 @@ void Item::render(Renderer renderer, int offX, int offY)
         };
         SDL_RenderFillRect(renderer, &r);
     }
+    assert(_stage1 >= 0 && _stage2 >= 0);
     auto tex  = (_overrideTex || _overrideSurf) ? _overrideTex
             : (_stage1<(int)_texs.size() && _stage2<(int)_texs[_stage1].size()) ? _texs[_stage1][_stage2]
             : nullptr;

--- a/test/core/test_jsonitem_state.cpp
+++ b/test/core/test_jsonitem_state.cpp
@@ -1,0 +1,200 @@
+#include <gtest/gtest.h>
+#include <tuple>
+#include <string_view>
+#include <nlohmann/json.hpp>
+#include "../../src/core/jsonitem.h"
+
+using namespace std;
+using nlohmann::json;
+
+#define ALL_ITEM_TYPES \
+    "static", \
+    "toggle", \
+    "progressive", \
+    "consumable", \
+    "progressive_toggle", \
+    "composite_toggle", \
+    "toggle_badged"
+
+
+typedef bool loops;
+typedef bool allowed_disabled;
+typedef std::tuple<std::string_view, loops, allowed_disabled> ItemTypeAndSubType;
+
+/// used to test state and stage validity of empty/minimal items after state changes
+class EmptyJsonItemState : public testing::TestWithParam<ItemTypeAndSubType>
+{
+};
+
+TEST_P(EmptyJsonItemState, AlwaysPositiveAndBackToInitial) {
+    auto jItem = json({
+        {"name", "item"},
+        {"type", std::get<0>(GetParam())},
+        {"codes", "Code"},
+        {"loop", std::get<1>(GetParam())},
+        {"allow_disabled", std::get<2>(GetParam())},
+    });
+    auto item = JsonItem::FromJSON(jItem);
+    int initialStage1 = item.getState();
+    int initialStage2 = item.getActiveStage();
+    ASSERT_GE(initialStage1, 0);
+    ASSERT_GE(initialStage2, 0);
+    EXPECT_FALSE(item.getCurrentName().empty());
+
+    // forth and back - left, right, left, right should get all types back to initial state
+    item.changeState(BaseItem::Action::Primary);
+    ASSERT_GE(item.getState(), 0);
+    ASSERT_GE(item.getActiveStage(), 0);
+    EXPECT_FALSE(item.getCurrentName().empty());
+
+    item.changeState(BaseItem::Action::Secondary);
+    ASSERT_GE(item.getState(), 0);
+    ASSERT_GE(item.getActiveStage(), 0);
+    EXPECT_FALSE(item.getCurrentName().empty());
+
+    item.changeState(BaseItem::Action::Primary);
+    item.changeState(BaseItem::Action::Secondary);
+    if (item.getType() != BaseItem::Type::CONSUMABLE) {
+        // FIXME: consumable has inconsistent stage1
+        EXPECT_EQ(item.getState(), initialStage1);
+    }
+    EXPECT_EQ(item.getActiveStage(), initialStage2);
+    ASSERT_GE(item.getState(), 0);
+    ASSERT_GE(item.getActiveStage(), 0);
+    EXPECT_FALSE(item.getCurrentName().empty());
+
+    item.changeState(BaseItem::Action::Next);
+    ASSERT_GE(item.getState(), 0);
+    ASSERT_GE(item.getActiveStage(), 0);
+    EXPECT_FALSE(item.getCurrentName().empty());
+
+    item.changeState(BaseItem::Action::Prev);
+    if (item.getType() != BaseItem::Type::CONSUMABLE) {
+        // FIXME: consumable has inconsistent stage1
+        EXPECT_EQ(item.getState(), initialStage1);
+    }
+    EXPECT_EQ(item.getActiveStage(), initialStage2);
+    ASSERT_GE(item.getState(), 0);
+    ASSERT_GE(item.getActiveStage(), 0);
+    EXPECT_FALSE(item.getCurrentName().empty());
+
+    item.changeState(BaseItem::Action::Toggle);
+    ASSERT_GE(item.getState(), 0);
+    ASSERT_GE(item.getActiveStage(), 0);
+    EXPECT_FALSE(item.getCurrentName().empty());
+
+    item.changeState(BaseItem::Action::Toggle);
+    if (item.getType() != BaseItem::Type::CONSUMABLE) {
+        // FIXME: consumable has inconsistent stage1
+        EXPECT_EQ(item.getState(), initialStage1);
+    }
+    EXPECT_EQ(item.getActiveStage(), initialStage2);
+    ASSERT_GE(item.getState(), 0);
+    ASSERT_GE(item.getActiveStage(), 0);
+    EXPECT_FALSE(item.getCurrentName().empty());
+
+    item.changeState(BaseItem::Action::Single);
+    ASSERT_GE(item.getState(), 0);
+    ASSERT_GE(item.getActiveStage(), 0);
+    EXPECT_FALSE(item.getCurrentName().empty());
+
+    item.changeState(BaseItem::Action::Single);
+    if (item.getType() != BaseItem::Type::CONSUMABLE) {
+        // FIXME: consumable has inconsistent stage1
+        EXPECT_EQ(item.getState(), initialStage1);
+    }
+    EXPECT_EQ(item.getActiveStage(), initialStage2);
+    ASSERT_GE(item.getState(), 0);
+    ASSERT_GE(item.getActiveStage(), 0);
+    EXPECT_FALSE(item.getCurrentName().empty());
+
+    // back from initial state (right)
+    item.changeState(BaseItem::Action::Secondary);
+    ASSERT_GE(item.getState(), 0);
+    ASSERT_GE(item.getActiveStage(), 0);
+    EXPECT_FALSE(item.getCurrentName().empty());
+
+    // back from initial state (back)
+    item = JsonItem::FromJSON(jItem);
+    item.changeState(BaseItem::Action::Prev);
+    ASSERT_GE(item.getState(), 0);
+    ASSERT_GE(item.getActiveStage(), 0);
+    EXPECT_FALSE(item.getCurrentName().empty());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllTypes,
+    EmptyJsonItemState,
+    testing::Combine(
+        testing::Values(ALL_ITEM_TYPES),
+        testing::Values(false, true),
+        testing::Values(false, true)
+    )
+);
+
+static auto jProgressiveNoDisabled = R"(
+{
+    "name": "item",
+    "type": "progressive",
+    "loop": false,
+    "allow_disabled": false,
+    "stages": [
+        {
+            "name": "stage1",
+            "codes": "code1"
+        },
+        {
+            "name": "stage2",
+            "codes": "code2"
+        },
+        {
+            "name": "stage3",
+            "codes": "code3"
+        }
+    ]
+}
+)"_json;
+
+/// used to test stage advancement of progressive items with allow_disabled = false
+class ProgressiveJsonItemState : public testing::TestWithParam<loops>
+{
+};
+
+/// tests that stage correctly advances for progressive to check validity of changeState in EmptyJsonItemState
+TEST_P(ProgressiveJsonItemState, Advances) {
+    auto jItem = jProgressiveNoDisabled;
+    bool loop = GetParam();
+    jItem["loop"] = loop;
+    auto item = JsonItem::FromJSON(jItem);
+
+    EXPECT_EQ(item.getState(), 1);
+    EXPECT_EQ(item.getActiveStage(), 0);
+    EXPECT_EQ(item.getCurrentName(), jItem["stages"][0]["name"]);
+
+    EXPECT_TRUE(item.changeState(BaseItem::Action::Primary));
+
+    EXPECT_EQ(item.getState(), 1);
+    EXPECT_EQ(item.getActiveStage(), 1);
+    EXPECT_EQ(item.getCurrentName(), jItem["stages"][1]["name"]);
+
+    EXPECT_TRUE(item.changeState(BaseItem::Action::Primary));
+
+    EXPECT_EQ(item.getState(), 1);
+    EXPECT_EQ(item.getActiveStage(), 2);
+    EXPECT_EQ(item.getCurrentName(), jItem["stages"][2]["name"]);
+
+    int expectedStage = loop ? 0 : 2;
+    bool expectedChanged = loop ? true : false; // item loops -> true, otherwise unchanged -> false
+
+    EXPECT_EQ(item.changeState(BaseItem::Action::Primary), expectedChanged);
+
+    EXPECT_EQ(item.getState(), 1);
+    EXPECT_EQ(item.getActiveStage(), expectedStage);
+    EXPECT_EQ(item.getCurrentName(), jItem["stages"][expectedStage]["name"]);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LoopAndNoLoop,
+    ProgressiveJsonItemState,
+    testing::Values(false, true)
+);


### PR DESCRIPTION
also adds tests to verify neither state (Active) nor stage (ActiveStage) becomes invalid for JsonItem during changeState
also adds an assert to getCurrentName to get a readable error should we ever reintroduce a wrong calculation
also adds an assert to Ui::Item to get a readable error should we ever apply an invalid state/stage to Ui::Item