### PR TITLE
CI: better concurrency

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -14,8 +14,12 @@ on:
       - 'macosx/*.sh'
       - 'win32/*.sh'
 
-jobs:
+concurrency:
+  # Cancels pending runs when a PR gets updated. (For push we'd use ref.)
+  group: "${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{ github.actor }}"
+  cancel-in-progress: true
 
+jobs:
   build-ubuntu:
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/scan-build.yaml
+++ b/.github/workflows/scan-build.yaml
@@ -32,6 +32,7 @@ concurrency:
 jobs:
   scan-build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/scan-build.yaml
+++ b/.github/workflows/scan-build.yaml
@@ -24,6 +24,11 @@ on:
       - '**.ipp'
       - '.github/workflows/scan-build.yaml'
 
+concurrency:
+  # Cancels pending runs when a PR gets updated. (For push we'd use ref.)
+  group: "${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{ github.actor }}"
+  cancel-in-progress: true
+
 jobs:
   scan-build:
     strategy:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, macos-latest]  # , macos-13  # for tests, only do special macos-13 build below
         shell: [bash]
         extra_make_args: ['']  # default build
         include:


### PR DESCRIPTION
* cancel previous runs of `scan-build` and `binaries` for the same PR since CI takes quite long now and the outdated results are typically useless
* don't fail fast for scan-build - let Windows finish if Linux failed in case they find different things
* skip the macos-13 default build, since the tested code paths are redundant