### PR TITLE
Test: fix unused variable warning in test_fs and test_pack

### DIFF
--- a/test/core/test_fs.cpp
+++ b/test/core/test_fs.cpp
@@ -38,7 +38,6 @@ static fs::path my_realpath(const fs::path& path)
 #else
     auto tmp = _wfullpath(nullptr, path.c_str(), 1024);
     if (tmp) {
-        auto cmp = [tmp](const fs::path& p) { return wcsicmp(tmp, p.c_str()) == 0; };
         res = tmp;
         free(tmp);
     }

--- a/test/core/test_pack.cpp
+++ b/test/core/test_pack.cpp
@@ -15,7 +15,6 @@ static fs::path my_realpath(const fs::path& path)
 #else
     auto tmp = _wfullpath(nullptr, path.c_str(), 1024);
     if (tmp) {
-        auto cmp = [tmp](const fs::path& p) { return wcsicmp(tmp, p.c_str()) == 0; };
         res = tmp;
         free(tmp);
     }


### PR DESCRIPTION
cmp was used to check if the function works and I forgot to remove it, resulting in an unused variable warning.
The second instance of it was a copy-pasta.