### PR TITLE
Change Allow Deferred Logic Update default for ap and add to settings.json

### DIFF
--- a/api/lua/definition/poptracker.lua
+++ b/api/lua/definition/poptracker.lua
@@ -85,6 +85,7 @@ Tracker.BulkUpdate = false
 
 ---Allow to evaluate logic rules fewer times than items are updated.
 ---Only available in PopTracker, since 0.28.1.
+---Since 0.31.0 defaults to true for flag 'ap' and gets initialized from settings.json. Honors target_poptracker_version.
 ---Use as: `if Tracker.AllowDeferredLogicUpdate ~= nil then Tracker.AllowDeferredLogicUpdate = true end`
 ---@type boolean
 Tracker.AllowDeferredLogicUpdate = false

--- a/doc/PACKS.md
+++ b/doc/PACKS.md
@@ -77,6 +77,7 @@ Configures behavior of the pack.
     {
         "smooth_scaling": true|false|null, // configure the image scaling method. null = default = currently crisp
         "smooth_map_scaling": true|false|null, // configure the image scaling method for maps. null = default = smooth
+        "allow_deferred_logic_update": true|false|null, // set initial value of Tracker.AllowDeferredLogicUpdate
     }
 
 NOTE: User overrides for settings are merged with the pack, replacing individual keys, not the whole file.

--- a/schema/packs/settings.json
+++ b/schema/packs/settings.json
@@ -13,6 +13,11 @@
             "description": "Sets scaling algorithm for maps. false = crisp, true = null = smooth",
             "type": ["boolean", "null"],
             "default": true
+        },
+        "allow_deferred_logic_update": {
+            "description": "Set to enable/disable deferred (faster) logic update. Can be overwritten from Lua as Tracker.AllowDeferredLogicUpdate.",
+            "type": ["boolean", "null"],
+            "default": null
         }
     }
 }

--- a/schema/packs/strict/settings.json
+++ b/schema/packs/strict/settings.json
@@ -7,7 +7,8 @@
         {
             "properties": {
                 "smooth_scaling": true,
-                "smooth_map_scaling": true
+                "smooth_map_scaling": true,
+                "allow_deferred_logic_update": true
             },
             "additionalProperties": false
         }

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -784,6 +784,11 @@ bool Tracker::allowDeferredLogicUpdate() const
     return _allowDeferredLogicUpdate;
 }
 
+void Tracker::setAllowDeferredLogicUpdate(bool value)
+{
+    _allowDeferredLogicUpdate = value;
+}
+
 const Pack* Tracker::getPack() const
 {
     return _pack;

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -104,6 +104,7 @@ public:
 
     bool isBulkUpdate() const;
     bool allowDeferredLogicUpdate() const;
+    void setAllowDeferredLogicUpdate(bool value);
 
     const Pack* getPack() const;
 

--- a/src/core/version.cpp
+++ b/src/core/version.cpp
@@ -69,6 +69,11 @@ bool Version::operator >(const Version& other) const
     return other < *this;
 }
 
+bool Version::operator >=(const Version& other) const
+{
+    return !(*this < other);
+}
+
 std::string Version::to_string() const
 {
     return std::to_string(Major) + "." + std::to_string(Minor) + "." + std::to_string(Revision) + Extra;

--- a/src/core/version.h
+++ b/src/core/version.h
@@ -19,6 +19,7 @@ public:
     
     bool operator<(const Version& other) const;
     bool operator>(const Version& other) const;
+    bool operator>=(const Version& other) const;
 
     std::string to_string() const;
 

--- a/src/poptracker.cpp
+++ b/src/poptracker.cpp
@@ -1181,11 +1181,13 @@ bool PopTracker::loadTracker(const fs::path& pack, const std::string& variant, b
 
     printf("Loading Tracker...\n");
     _tracker = new Tracker(_pack, _L);
-    // set tracker defaults from settings.json
+    // set tracker defaults from settings.json and TargetPopTrackerVersion
     const auto& settings = _pack->getSettings();
     auto itAllowDeferredLogicUpdate = settings.find("allow_deferred_logic_update");
     if (itAllowDeferredLogicUpdate != settings.end() && itAllowDeferredLogicUpdate.value().is_boolean())
         _tracker->setAllowDeferredLogicUpdate(itAllowDeferredLogicUpdate.value());
+    else if (_pack->getVariantFlags().count("ap") && (targetLatest || targetVersion >= Version{0, 31, 0}))
+        _tracker->setAllowDeferredLogicUpdate(true);
     printf("Registering in Lua...\n");
     Tracker::Lua_Register(_L);
     _tracker->Lua_Push(_L);

--- a/src/poptracker.cpp
+++ b/src/poptracker.cpp
@@ -1181,6 +1181,11 @@ bool PopTracker::loadTracker(const fs::path& pack, const std::string& variant, b
 
     printf("Loading Tracker...\n");
     _tracker = new Tracker(_pack, _L);
+    // set tracker defaults from settings.json
+    const auto& settings = _pack->getSettings();
+    auto itAllowDeferredLogicUpdate = settings.find("allow_deferred_logic_update");
+    if (itAllowDeferredLogicUpdate != settings.end() && itAllowDeferredLogicUpdate.value().is_boolean())
+        _tracker->setAllowDeferredLogicUpdate(itAllowDeferredLogicUpdate.value());
     printf("Registering in Lua...\n");
     Tracker::Lua_Register(_L);
     _tracker->Lua_Push(_L);

--- a/test/core/test_version.cpp
+++ b/test/core/test_version.cpp
@@ -13,7 +13,9 @@ TEST(VersionTest, CompareBasic) {
     EXPECT_FALSE(Version(1, 0, 0) < Version("1"));
     EXPECT_FALSE(Version(1, 0, 0) < Version("1.0"));
     EXPECT_FALSE(Version(1, 0, 0) < Version("1.0.0"));
+    EXPECT_TRUE(Version(1, 0, 0) >= Version("1.0.0"));
     EXPECT_TRUE(Version("1.2.3-1something2") < Version("1.2.3-2something1"));
+    EXPECT_FALSE(Version("1.2.3-1something2") >= Version("1.2.3-2something1"));
 }
 
 TEST(VersionTest, CompareSemVer) {


### PR DESCRIPTION
* allows setting value from settings.json (can be overwritten from Lua)
* changes default for packs with 'ap' flag to true unless target version is < 0.31.0