### PR TITLE
Lua: read the merged settings.json with io

### DIFF
--- a/examples/read-settings-test/scripts/init.lua
+++ b/examples/read-settings-test/scripts/init.lua
@@ -7,3 +7,4 @@ local settings_data = settings_file:read("*all")
 settings_file:close()
 local settings = json.decode(settings_data)
 print(settings["key"])  -- should print "value"
+print(settings["key2"])  -- should print "nil"

--- a/src/core/pack.h
+++ b/src/core/pack.h
@@ -54,7 +54,7 @@ public:
     Info getInfo() const;
     
     bool hasFile(const std::string& file) const;
-    bool ReadFile(const std::string& file, std::string& out) const;
+    bool ReadFile(const std::string& file, std::string& out, bool allowOverride=true) const;
     
     bool variantHasFlag(const std::string& flag) const;
     std::set<std::string> getVariantFlags() const;


### PR DESCRIPTION
When using user override for settings.json, the final version is merged from pack + override key by key. This was not the case when reading the file using io from Lua and it would instead ignore the override completely.