### PR TITLE
Add pub keys for minisign

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -395,6 +395,7 @@ $(WIN32_ZIP) $(WIN64_ZIP):
 	cp -r api $(TMP_DIR)/poptracker/
 	cp -r schema $(TMP_DIR)/poptracker/
 	cp -r assets $(TMP_DIR)/poptracker/
+	cp -r key $(TMP_DIR)/poptracker/
 	cp LICENSE README.md CHANGELOG.md CREDITS.md $(TMP_DIR)/poptracker/
 	cp $(dir $<)*.exe $(TMP_DIR)/poptracker/
 	cp $(dir $<)*.dll $(TMP_DIR)/poptracker/ || true
@@ -430,6 +431,7 @@ $(NIX_XZ): $(NIX_EXE) | $(DIST_DIR)
 	cp -r api $(TMP_DIR)/poptracker/
 	cp -r schema $(TMP_DIR)/poptracker/
 	cp -r assets $(TMP_DIR)/poptracker/
+	cp -r key $(TMP_DIR)/poptracker/
 	cp LICENSE README.md CHANGELOG.md CREDITS.md $(TMP_DIR)/poptracker/
 	cp $(NIX_EXE) $(TMP_DIR)/poptracker/
 	rm -f $@

--- a/key/3B69F3B9A853297F.pub
+++ b/key/3B69F3B9A853297F.pub
@@ -1,0 +1,2 @@
+untrusted comment: minisign public key 3B69F3B9A853297F alias backup not before 1743356631 not after 1806428631
+RWR/KVOoufNpOxFX4VZUW/gDaRnlr5tJkRIHNIvaC0qxbbYPTxOX22q9

--- a/key/F93AE9DB05595CD3.pub
+++ b/key/F93AE9DB05595CD3.pub
@@ -1,0 +1,2 @@
+untrusted comment: minisign public key F93AE9DB05595CD3 alias black-sliver not before 1743356631 not after 1774892631
+RWTTXFkF2+k6+QiNdyF96/Xmm6YcFl1Y7IhTc3lUrEhwJyf+FwBqQ/8Z

--- a/linux/AppImageBuilder.yml
+++ b/linux/AppImageBuilder.yml
@@ -133,5 +133,5 @@ script: |
   cp -r assets "$TARGET_APPDIR/usr/bin/."
 
   mkdir -p "$TARGET_APPDIR/usr/share/poptracker"
-  cp -r api schema "$TARGET_APPDIR/usr/share/poptracker/."
+  cp -r api schema key "$TARGET_APPDIR/usr/share/poptracker/."
   rm "$TARGET_APPDIR/usr/share/poptracker/"*/README.md

--- a/macosx/bundle_macosx_app.sh
+++ b/macosx/bundle_macosx_app.sh
@@ -74,6 +74,7 @@ ROOT_DIR="$SRC_DIR/.."
 SRC_ASSETS_DIR="$ROOT_DIR/assets"
 SRC_API_DIR="$ROOT_DIR/api"
 SRC_SCHEMA_DIR="$ROOT_DIR/schema"
+SRC_KEY_DIR="$ROOT_DIR/key"
 DOCS="$ROOT_DIR/LICENSE $ROOT_DIR/README.md $ROOT_DIR/CHANGELOG.md $ROOT_DIR/CREDITS.md"
 
 APP_BUNDLE_DIR="$DST_DIR/$BUNDLE_NAME.app"
@@ -131,9 +132,10 @@ cp $EXE $DST_EXE
 cp -r $SRC_ASSETS_DIR $APP_BUNDLE_MACOS_DIR
 cp -r $DOCS $APP_BUNDLE_MACOS_DIR
 
-# Copy schema and api into app bundle
+# Copy schema, api and key into app bundle
 cp -r "$SRC_API_DIR" "$APP_BUNDLE_RESOURCES_DIR"
 cp -r "$SRC_SCHEMA_DIR" "$APP_BUNDLE_RESOURCES_DIR"
+cp -r "$SRC_KEY_DIR" "$APP_BUNDLE_RESOURCES_DIR"
 rm "$APP_BUNDLE_RESOURCES_DIR/"*/README.md
 
 # Build third party libraries and update dynamic paths


### PR DESCRIPTION
F93AE9DB05595CD3 is the primary pub key file for minisign
3B69F3B9A853297F is a backup pub key file for minisign

i.e. use 
```bash
minisign -V -H -p key/F93AE9DB05595CD3.pub -m path/to/file
```
and if that says `Signature key id in path/to/file.minisig is 3B69F3B9A853297F`, use the other one.

The files contain a timestamp for when I want to rotate them. This is 1 year from now for the primary and 2 years from now for the backup key.