### PR TITLE
CI: add ARM builds/tests

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -25,9 +25,17 @@ permissions:
 
 jobs:
   build-ubuntu:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-22.04
+          - ubuntu-22.04-arm
 
     steps:
+    - name: Set env
+      shell: bash
+      run: echo "ARCH=`uname -m`" >> $GITHUB_ENV
     - name: Install dependencies
       run: |
         sudo apt-get update -y -qq
@@ -41,8 +49,8 @@ jobs:
       run: make test CONF=RELEASE
     - name: Get version
       run: |
-        echo "POP_VERSION=`./build/linux-x86_64/poptracker --version`" >> $GITHUB_ENV
-        echo "POP_NAME=poptracker_`./build/linux-x86_64/poptracker --version | tr '.' '-'`" >> $GITHUB_ENV
+        echo "POP_VERSION=`./build/linux-${{ matrix.ARCH }}/poptracker --version`" >> $GITHUB_ENV
+        echo "POP_NAME=poptracker_`./build/linux-${{ matrix.ARCH }}/poptracker --version | tr '.' '-'`" >> $GITHUB_ENV
     - name: Build DIST # this builds a release ZIP, maybe .deb in the future
       run: make CONF=DIST
     - name: Attest Build and Archive
@@ -50,12 +58,12 @@ jobs:
       uses: actions/attest-build-provenance@v2
       with:
         subject-path: |
-          build/linux-x86_64/poptracker
+          build/linux-${{ matrix.ARCH }}/poptracker
           dist/*
     - name: Store DIST
       uses: actions/upload-artifact@v4
       with:
-        name: ubuntu-22-04-dist
+        name: ${{ matrix.os }}-dist
         path: dist
 
   build-appimage:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,11 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]  # , macos-13  # for tests, only do special macos-13 build below
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-latest
+          # - macos-13  # for tests, only do special macos-13 build below
         shell: [bash]
         extra_make_args: ['']  # default build
         include:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,9 @@ jobs:
           - os: windows-latest
             shell: msys2 {0}
             extra_make_args: ''
+          - os:  windows-11-arm
+            shell: msys2 {0}
+            extra_make_args: ''
           - os: macos-13
             shell: bash
             # we now require 10.15 by default, but 10.13 should work with an extra dependency
@@ -66,8 +69,8 @@ jobs:
       if: ${{ startsWith(matrix.os, 'macos') && contains(matrix.extra_make_args, 'MACOS_DEPLOYMENT_TARGET') }}
       run: |
         brew install boost || true
-    - name: Install dependencies (msys2)
-      if: ${{ startsWith(matrix.os, 'windows') }}
+    - name: Install dependencies (msys2, x86_64)
+      if: ${{ startsWith(matrix.os, 'windows') && !endsWith(matrix.os, 'arm')}}
       uses: msys2/setup-msys2@v2
       with:
         release: false
@@ -83,6 +86,25 @@ jobs:
           mingw64/mingw-w64-x86_64-freetype
           mingw64/mingw-w64-x86_64-openssl
           mingw64/mingw-w64-x86_64-gtest
+          p7zip
+    - name: Install dependencies (msys2, arm)
+      if: ${{ startsWith(matrix.os, 'windows') && endsWith(matrix.os, 'arm')}}
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: CLANGARM64
+        update: true
+        install: >-
+          base-devel
+          coreutils
+          make
+          mingw-w64-clang-aarch64-toolchain
+          clangarm64/mingw-w64-clang-aarch64-gcc-compat
+          clangarm64/mingw-w64-clang-aarch64-SDL2
+          clangarm64/mingw-w64-clang-aarch64-SDL2_image
+          clangarm64/mingw-w64-clang-aarch64-SDL2_ttf
+          clangarm64/mingw-w64-clang-aarch64-freetype
+          clangarm64/mingw-w64-clang-aarch64-openssl
+          clangarm64/mingw-w64-clang-aarch64-gtest
           p7zip
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
#### Changes
* add Windows 11 ARM to the test matrix
* add Ubuntu (latest) ARM to the test matrix
* add Ubuntu-22.04 ARM build to build binaries

#### TODO
* Ubuntu-22.04 ARM AppImage
* change filename of the Windows ARM build
* add new builds to the release action