### PR TITLE
Ui: fix wrong click when window is unfocused

### DIFF
--- a/src/uilib/ui.cpp
+++ b/src/uilib/ui.cpp
@@ -176,7 +176,7 @@ bool Ui::render()
         
         // Work around SDL eating mouse input when switching windows
         // read below at SDL_WINDOWEVENT_FOCUS_GAINED
-        if (_globalMouseButton) {
+        if (_globalMouseButtons) {
             if (!SDL_GetGlobalMouseState(nullptr, nullptr)) {
 #ifdef UI_ENABLE_UNFOCUSED_CLICK_HACK
                 // untracked mouse button released ...
@@ -189,14 +189,19 @@ bool Ui::render()
                     ev.type = SDL_MOUSEBUTTONDOWN;
                     ev.button.x = (Sint32)x;
                     ev.button.y = (Sint32)y;
-                    ev.button.button = (Uint8) _globalMouseButton;
+                    for (uint8_t button=0; button < sizeof(_globalMouseButtons) * 8; ++button) {
+                        if (_globalMouseButtons & (1 << button)) {
+                            ev.button.button = button + 1; // button enum starts at 1
+                            break;
+                        }
+                    }
                     ev.button.windowID = SDL_GetWindowID(win);
                     SDL_PushEvent(&ev);
                     ev.type = SDL_MOUSEBUTTONUP;
                     SDL_PushEvent(&ev);
                 }
 #endif // UI_ENABLE_UNFOCUSED_CLICK_HACK
-                _globalMouseButton = 0;
+                _globalMouseButtons = 0;
             }
         }
         
@@ -209,7 +214,7 @@ bool Ui::render()
                 }
                 case SDL_MOUSEBUTTONDOWN: {
                     // clear/cancel cached "global" event (see above or below)
-                    _globalMouseButton = 0;
+                    _globalMouseButtons = 0;
                     // ignore. We click() on SDL_MOUSEBUTTONUP
                     break;
                 }
@@ -332,7 +337,7 @@ bool Ui::render()
                         if (button && _lastEventType != SDL_MOUSEBUTTONDOWN) {
                             SDL_Window* win = SDL_GetMouseFocus();
                             if (win) {
-                                _globalMouseButton = button;
+                                _globalMouseButtons = button;
                             }
                         }
                     }

--- a/src/uilib/ui.cpp
+++ b/src/uilib/ui.cpp
@@ -24,6 +24,7 @@
 #   define EVENT_UNLOCK(self)
 #endif
 
+#define UI_ENABLE_UNFOCUSED_CLICK_HACK
 
 namespace Ui {
 
@@ -177,6 +178,7 @@ bool Ui::render()
         // read below at SDL_WINDOWEVENT_FOCUS_GAINED
         if (_globalMouseButton) {
             if (!SDL_GetGlobalMouseState(nullptr, nullptr)) {
+#ifdef UI_ENABLE_UNFOCUSED_CLICK_HACK
                 // untracked mouse button released ...
                 SDL_Window* win = SDL_GetMouseFocus();
                 if (win) {
@@ -193,6 +195,7 @@ bool Ui::render()
                     ev.type = SDL_MOUSEBUTTONUP;
                     SDL_PushEvent(&ev);
                 }
+#endif // UI_ENABLE_UNFOCUSED_CLICK_HACK
                 _globalMouseButton = 0;
             }
         }

--- a/src/uilib/ui.h
+++ b/src/uilib/ui.h
@@ -29,7 +29,7 @@ protected:
     std::string _name;
     unsigned _lastRenderDuration = 0;
     uint64_t _lastFrameMicroTimestamp = 0;
-    unsigned _globalMouseButton = 0;
+    unsigned _globalMouseButtons = 0; ///< bit mask of pressed mouse buttons during last capture
     Uint32 _lastEventType = 0;
     bool _fallbackRenderer = false;
     unsigned _fpsLimit = 0;


### PR DESCRIPTION
The code that detects a click when a window is unfocused would register the wrong mouse button if it's not Button 1.