### PR TITLE
Ui: hosted item cleanup in trackerview

### DIFF
--- a/src/ui/trackerview.cpp
+++ b/src/ui/trackerview.cpp
@@ -976,9 +976,8 @@ bool TrackerView::addLayoutNode(Container* container, const LayoutNode& node, si
                                 }
                                 last = n;
                                 sec.clearItem(true);
-                                std::list<std::string> codes = sec.getHostedItems();
-                                for (const auto& item: codes) {
-                                    tracker->changeItemState(tracker->getItemByCode(item).getID(),
+                                for (const auto& code: sec.getHostedItems()) {
+                                    tracker->changeItemState(tracker->getItemByCode(code).getID(),
                                             ::BaseItem::Action::Primary);
                                 }
                                 done = false;
@@ -1067,9 +1066,10 @@ int TrackerView::CalculateLocationState(Tracker* tracker, const std::string& loc
         if (!tracker->isVisible(loc, sec))
             continue;
 
-        std::list<std::string> hostedItems;
+        std::vector<std::string> hostedItems;
         if (sec.getItemCleared() >= sec.getItemCount()) {
             // be lazy about filling hostedItems
+            hostedItems.reserve(sec.getHostedItems().size());
             for (const auto& code : sec.getHostedItems()) {
                 if (tracker->getItemByCode(code).getType() != BaseItem::Type::NONE)
                     hostedItems.push_back(code);


### PR DESCRIPTION
The first change avoids a useless copy of `list<string>`, but requires that `Section::_hostedItems` can not be modified from Lua. This is (currently) true with both `MERGE_DUPLICATE_LOCATIONS` defined and undefined and changing that would most likely break in other places, so we did not leave a note in code,

The second change avoids a bunch of mallocs and improves cache efficiency in a hot code path.