### PR TITLE
Ui: set more reasonable min size for DefaultTrackerWindow

### DIFF
--- a/src/ui/defaulttrackerwindow.cpp
+++ b/src/ui/defaulttrackerwindow.cpp
@@ -330,6 +330,11 @@ void DefaultTrackerWindow::setSize(Size size)
     }
 }
 
+void DefaultTrackerWindow::setMinSize(const Size size)
+{
+    TrackerWindow::setMinSize(size || Size{220, 0});
+}
+
 void DefaultTrackerWindow::showOpen()
 {
     _loadPackWidget->update();

--- a/src/ui/defaulttrackerwindow.h
+++ b/src/ui/defaulttrackerwindow.h
@@ -19,6 +19,7 @@ public:
     virtual void setTracker(Tracker* tracker) override;
     virtual void setAutoTrackerState(int index, AutoTracker::State state, const std::string& name, const std::string& subname) override;
     virtual void setSize(Size size) override;
+    void setMinSize(Size size) override;
     virtual void showOpen();
     virtual void hideOpen();
     virtual void showProgress(const std::string& title, int progress, int max);


### PR DESCRIPTION
This is technically a layout change, so merge for 0.32.0, not 0.31.x