### PR TITLE
Ui: fix array breaking when size < content

### DIFF
--- a/src/uilib/hbox.h
+++ b/src/uilib/hbox.h
@@ -68,7 +68,7 @@ public:
             child->setTop(child->getMargin().top + _padding);
             child->setHeight(_size.height - child->getTop() - child->getMargin().bottom - _padding);
             child->setLeft(x);
-            x += child->getWidth() + child->getMargin().right + _spacing;
+            x += std::max(0, child->getWidth()) + child->getMargin().right + _spacing;
         }
         calcMinMax();
     }

--- a/src/uilib/hbox.h
+++ b/src/uilib/hbox.h
@@ -55,7 +55,8 @@ public:
             // if only the last child grows, we can skip resizing all children and we could skip the relayout
             if (extraWidth != 0 && totalHGrow == _children.back()->getHGrow() && _children.back()->getMaxWidth() != _children.back()->getWidth()) {
                 auto child = _children.back();
-                child->setWidth(_size.width - _padding - child->getLeft());
+                if (_size.width - _padding > child->getLeft())
+                    child->setWidth(_size.width - _padding - child->getLeft());
             }
             else if (extraWidth != 0 && totalHGrow > 0) {
                 for (auto child: _children)

--- a/src/uilib/vbox.h
+++ b/src/uilib/vbox.h
@@ -57,7 +57,7 @@ public:
             y += child->getMargin().top;
             child->setLeft(child->getMargin().left + _padding);
             child->setTop(y);
-            y += child->getHeight() + child->getMargin().right + _spacing;
+            y += std::max(0, child->getHeight()) + child->getMargin().right + _spacing;
         }
         calcMinMax();
     }


### PR DESCRIPTION
For layouts, we properly populate min_size, so this typically does not happen, however it can happen for menu and possibly other elements that don't use min_size.