### PR TITLE
Fix reset not checking checked locations for apmanual

### DIFF
--- a/src/ap/aptracker.h
+++ b/src/ap/aptracker.h
@@ -1,5 +1,4 @@
-#ifndef _AP_APTRACKER_H
-#define _AP_APTRACKER_H
+#pragma once
 
 // APTracker wraps APClient to provide a simpler interface to core/AutoTracker
 #include <apclientpp/apclient.hpp>
@@ -326,7 +325,16 @@ public:
     {
         if (!_allowSend || !_ap)
             return false;
-        return _ap->LocationChecks(locations);
+        if (!_ap->LocationChecks(locations))
+            return false;
+        for (auto location: locations) {
+            auto it = _uncheckedLocations.find(location);
+            if (it != _uncheckedLocations.end()) {
+                _checkedLocations.insert(location);
+                _uncheckedLocations.erase(it);
+            }
+        }
+        return true;
     }
 
     /// returns true if locations were queued to be scouted
@@ -385,5 +393,3 @@ private:
         int& _event;
     };
 };
-
-#endif // _AP_APTRACKER_H

--- a/src/ap/aptracker.h
+++ b/src/ap/aptracker.h
@@ -150,7 +150,9 @@ public:
                     // we started a sync to reset state -> replay onClear and onLocationChecked
                     _syncing = false;
                     onClear.emit(this, _slotData);
-                    for (int64_t location: _checkedLocations) {
+                    // create copy in case Lua checks locations
+                    const auto checkedLocations = _checkedLocations;
+                    for (int64_t location: checkedLocations) {
                         _uncheckedLocations.erase(location);
                         onLocationChecked.emit(this, location, _ap->get_location_name(location, _ap->get_game()));
                     }
@@ -298,7 +300,9 @@ public:
         } else if (!_syncing) {
             // never received an item, so we can immediately run onClear
             onClear.emit(this, _slotData);
-            for (int64_t location: _checkedLocations) {
+            // create copy in case Lua checks locations
+            const auto checkedLocations = _checkedLocations;
+            for (int64_t location: checkedLocations) {
                 _uncheckedLocations.erase(location);
                 onLocationChecked.emit(this, location, _ap->get_location_name(location, _ap->get_game()));
             }


### PR DESCRIPTION
Also fixes Archipelago.CheckedLocations being out of sync.
Also minor cleanup.
Also fixes a potential crash (that was not possible to reach before).