### PR TITLE
Add stable item IDs for save/load state

### DIFF
--- a/src/core/baseitem.h
+++ b/src/core/baseitem.h
@@ -88,7 +88,9 @@ protected:
     int _maxCount = 0; // for consumable
     int _increment = 1; // for consumable
     int _decrement = 1; // for consumables
+
     std::string _baseItem; // for toggle_badged
+    std::string _stableId;
     
 public:
     virtual ~BaseItem() {}
@@ -102,9 +104,21 @@ public:
     bool getLoop() const { return _loop; }
     bool getAllowDisabled() const { return _allowDisabled; }
 
+    /// Gets the stable item ID, which can be used to save/restore state even when a pack has changed.
+    const std::string& getStableID() const { return _stableId; }
+
+    /// Sets an item ID, which can be used to track the item. It is not guaranteed stable across pack reloads.
     void setID(const std::string& id) { _id = id; }
-    void setID(uint64_t id) { setID(std::to_string(id)); }
-    
+    /// Sets an item ID, which can be used to track the item. It is not guaranteed stable across pack reloads.
+    void setID(std::string&& id) { _id = id; }
+    /// Sets an item ID, which is used internally to track the item. It is not guaranteed stable across pack reloads.
+    void setID(const uint64_t id) { setID(std::to_string(id)); }
+
+    /// Sets a stable item ID, which should be suitable to save/restore state even when a pack has changed.
+    void setStableID(const std::string& stableID) { _stableId = stableID; }
+    /// Sets a stable item ID, which can be used to save/restore state when a pack has changed.
+    void setStableID(std::string&& stableID) { _stableId = stableID; }
+
     //virtual const std::vector<Stage>& getStages() const { return _stages; }
     
     virtual size_t getStageCount() const { return 0; }

--- a/src/core/baseitem.h
+++ b/src/core/baseitem.h
@@ -1,5 +1,4 @@
-#ifndef _CORE_BASEITEM_H
-#define _CORE_BASEITEM_H
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -7,6 +6,7 @@
 #include <vector>
 #include <algorithm>
 #include "signal.h"
+
 
 class BaseItem { // TODO: move stuff over to JsonItem; TODO: make some stuff pure virtual?
 public:
@@ -97,11 +97,11 @@ public:
     virtual const std::string& getCurrentName() const { return _name; }
     const std::string& getID() const { return _id; }
     const std::string& getBaseItem() const { return _baseItem; }
-    const Type getType() const { return _type; }
-    const bool getCapturable() const { return _capturable; }
-    const bool getLoop() const { return _loop; } 
-    const bool getAllowDisabled() const { return _allowDisabled; }
-    
+    Type getType() const { return _type; }
+    bool getCapturable() const { return _capturable; }
+    bool getLoop() const { return _loop; }
+    bool getAllowDisabled() const { return _allowDisabled; }
+
     void setID(const std::string& id) { _id = id; }
     void setID(uint64_t id) { setID(std::to_string(id)); }
     
@@ -135,7 +135,7 @@ public:
         if (std::find(_codes.begin(), _codes.end(), code) != _codes.end()) return true;
         return false;
     }
-    
+
     virtual std::string getCodesString() const;
     virtual int getState() const { return _allowDisabled ? _stage1 : 1; }
     virtual int getActiveStage() const { return _stage2; }
@@ -159,5 +159,3 @@ public:
     virtual void SetOverlayFontSize(int fontSize) = 0;
     virtual void SetOverlayColor(const char* text) = 0;
 };
-
-#endif // _CORE_BASEITEM_H

--- a/src/core/jsonitem.h
+++ b/src/core/jsonitem.h
@@ -1,5 +1,4 @@
-#ifndef _CORE_JSONITEM_H
-#define _CORE_JSONITEM_H
+#pragma once
 
 #include "baseitem.h"
 #include <luaglue/luainterface.h>
@@ -47,7 +46,10 @@ public:
         const std::vector<std::string>& getCodes() const { return _codes; }
         const std::list<std::string>& getSecondaryCodes() const { return _secondaryCodes; }
         std::string getCodesString() const;
-        bool hasCode(const std::string& code) const { // NOTE: this is called canProvideCode in lua
+
+        bool hasCode(const std::string& code) const
+        {
+            // NOTE: this is called canProvideCode in Lua
 #ifdef JSONITEM_CI_QUIRK
             const auto cmp = [&code](const std::string& s) {
                 return code.length() == s.length() && strcasecmp(code.c_str(), s.c_str()) == 0;
@@ -57,10 +59,13 @@ public:
             return std::find(_codes.begin(), _codes.end(), code) != _codes.end();
 #endif
         }
-        bool hasSecondaryCode(const std::string& code) const {
+
+        bool hasSecondaryCode(const std::string& code) const
+        {
             return std::find(_secondaryCodes.begin(), _secondaryCodes.end(), code) != _secondaryCodes.end();
         }
-        const bool getInheritCodes() const { return _inheritCodes; }
+
+        bool getInheritCodes() const { return _inheritCodes; }
         const std::string& getName() const { return _name; }
     };
 
@@ -95,31 +100,38 @@ public:
         return s;
     }
 
-    virtual size_t getStageCount() const override { return _stages.size(); }
+    size_t getStageCount() const override { return _stages.size(); }
     
-    virtual const std::string& getImage(size_t stage) const override {
+    const std::string& getImage(size_t stage) const override
+    {
         if (_type == Type::TOGGLE) return _img;
         if (_stages.size()>stage) return _stages[stage].getImage();
         return _img;
     }
-    virtual const std::string& getDisabledImage(size_t stage) const override {
+
+    const std::string& getDisabledImage(size_t stage) const override
+    {
         if (_type == Type::TOGGLE) return _disabledImg;
         if (_stages.size()>stage) return _stages[stage].getDisabledImage();
         return _disabledImg;
     }
     
-    virtual const std::list<std::string>& getImageMods(int stage) const override {
+    const std::list<std::string>& getImageMods(int stage) const override
+    {
         if (_type == Type::TOGGLE) return _imgMods;
         if ((int)_stages.size()>stage) return _stages[stage].getImageMods();
         return _imgMods;
     }
-    virtual const std::list<std::string>& getDisabledImageMods(int stage) const override {
+
+    const std::list<std::string>& getDisabledImageMods(int stage) const override
+    {
         if (_type == Type::TOGGLE) return _disabledImgMods;
         if ((int)_stages.size()>stage) return _stages[stage].getDisabledImageMods();
         return _disabledImgMods;
     }
     
-    virtual const std::string& getCurrentName() const override {
+    const std::string& getCurrentName() const override
+    {
         if ((int)_stages.size() > _stage2) {
             assert(_stage2 >= 0);
             if (!_stages[_stage2].getName().empty())
@@ -135,7 +147,8 @@ public:
     }
 #endif
 
-    virtual bool canProvideCode(const std::string& code) const override {
+    bool canProvideCode(const std::string& code) const override
+    {
 #ifdef JSONITEM_CI_QUIRK
         const auto cmp = [&code](const std::string& s) {
             return code.length() == s.length() && strcasecmp(code.c_str(), s.c_str()) == 0;
@@ -206,7 +219,8 @@ public:
     std::string getCodesString() const override;
     const std::vector<std::string>& getCodes(int stage) const;
     
-    virtual bool changeState(BaseItem::Action action) override {
+    bool changeState(const Action action) override
+    {
         if (_ignoreUserInput)
             return false;
         if (_changeStateImpl(action)) {
@@ -222,7 +236,9 @@ public:
         }
         return false;
     }
-    virtual bool setState(int state, int stage=-1) override {
+
+    bool setState(int state, int stage=-1) override
+    {
         // NOTE: we have to override because upcasting sender from void* in onChange does not work with multiple inheritance
         if (state<0) state = _stage1;
         if (stage<0) stage = _stage2;
@@ -237,27 +253,31 @@ public:
         return false;
     }
     
-    virtual void SetOverlay(const char* text) override {
+    void SetOverlay(const char* text) override
+    {
         if (_overlay == text) return;
         _overlay = text;
         onChange.emit(this);
     }
 
-    virtual void SetOverlayBackground(const char* text) override {
+    void SetOverlayBackground(const char* text) override
+    {
         if (_overlayBackground == text) return;
         _overlayBackgroundChanged = true;
         _overlayBackground = text;
         onChange.emit(this);
     }
 
-    virtual void SetOverlayAlign(const char* align) override {
+    void SetOverlayAlign(const char* align) override
+    {
         if (_overlayAlign == align) return;
         _overlayAlignChanged = true;
         _overlayAlign = align;
         onChange.emit(this);
     }
 
-    virtual void SetOverlayFontSize(int fontSize) override {
+    void SetOverlayFontSize(int fontSize) override
+    {
         if (_overlayFontSize == fontSize) return;
         _overlayFontSizeChanged = true;
         _overlayFontSize = fontSize;
@@ -281,8 +301,8 @@ public:
         return _imgOverride;
     }
 
-    virtual nlohmann::json save() const;
-    virtual bool load(nlohmann::json& j);
+    nlohmann::json save() const;
+    bool load(nlohmann::json& j);
     
 protected:
     
@@ -290,12 +310,9 @@ protected:
     
 protected: // Lua interface implementation
     
-    static constexpr const char Lua_Name[] = "JsonItem";
-    static const LuaInterface::MethodMap Lua_Methods;
+    static constexpr char Lua_Name[] = "JsonItem";
+    static const MethodMap Lua_Methods;
     
-    virtual int Lua_Index(lua_State *L, const char* key) override;
-    virtual bool Lua_NewIndex(lua_State *L, const char *key) override;
+    int Lua_Index(lua_State *L, const char* key) override;
+    bool Lua_NewIndex(lua_State *L, const char *key) override;
 };
-
-#endif /* _CORE_JSONITEM_H */
-

--- a/src/core/jsonitem.h
+++ b/src/core/jsonitem.h
@@ -140,6 +140,9 @@ public:
         return _name;
     }
 
+    /// Generates and assigns a (hopefully) stable item ID to the item.
+    void makeStableID(std::map<std::string, int>& counter);
+
 #ifdef JSONITEM_CI_QUIRK
     bool canProvideCodeLower(const std::string& code) const
     {

--- a/src/core/luaitem.h
+++ b/src/core/luaitem.h
@@ -1,65 +1,72 @@
-#ifndef _CORE_LUAITEM_H
-#define _CORE_LUAITEM_H
+#pragma once
 
 #include <string>
 #include <list>
-#include <vector>
-#include <algorithm>
 #include <nlohmann/json.hpp>
 #include "baseitem.h"
 #include <luaglue/luainterface.h>
 #include <luaglue/luavariant.h>
 
+
 class LuaItem final : public LuaInterface<LuaItem>, public BaseItem {
     friend class LuaInterface;
 
 public:
-    LuaItem() {_type = BaseItem::Type::CUSTOM;}
-    
+    LuaItem()
+    {
+        _type = Type::CUSTOM;
+    }
+
     void Set(const char* key, LuaVariant value);
     LuaVariant Get(const char* key);
-    
-    virtual bool canProvideCode(const std::string& code) const override;
+
+    bool canProvideCode(const std::string& code) const override;
     int providesCode(const std::string& code) const override;
-    virtual bool changeState(Action action) override;
-    
-    virtual void SetOverlay(const char* text) override {
+    bool changeState(Action action) override;
+
+    void SetOverlay(const char* text) override
+    {
         if (_overlay == text) return;
         _overlay = text;
         onChange.emit(this);
     }
 
-    virtual void SetOverlayBackground(const char* text) override {
+    void SetOverlayBackground(const char* text) override
+    {
         if (_overlayBackground == text) return;
         _overlayBackground = text;
         onChange.emit(this);
     }
 
-    virtual void SetOverlayAlign(const char* align) override {
+    void SetOverlayAlign(const char* align) override
+    {
         if (_overlayAlign == align) return;
         _overlayAlign = align;
         onChange.emit(this);
     }
 
-    virtual void SetOverlayFontSize(int fontSize) override {
+    void SetOverlayFontSize(int fontSize) override
+    {
         if (_overlayFontSize == fontSize) return;
         _overlayFontSize = fontSize;
         onChange.emit(this);
     }
 
-    void SetOverlayColor(const char* text) override {
+    void SetOverlayColor(const char* text) override
+    {
         if (_overlayColor == text)
             return;
         _overlayColor = text;
         onChange.emit(this);
     }
 
-    virtual bool setState(int state, int stage=-1) override {
+    bool setState(int state, int stage=-1) override
+    {
         return false; // TODO: implement this?
     }
 
-    virtual nlohmann::json save() const;
-    virtual bool load(nlohmann::json& j);
+    nlohmann::json save() const;
+    bool load(nlohmann::json& j);
     
 private:
     lua_State *_L = nullptr; // FIXME: fix this
@@ -84,11 +91,9 @@ private:
 
 protected: // Lua interface implementation
     
-    static constexpr const char Lua_Name[] = "LuaItem";
-    static const LuaInterface::MethodMap Lua_Methods;
+    static constexpr char Lua_Name[] = "LuaItem";
+    static const MethodMap Lua_Methods;
     
-    virtual int Lua_Index(lua_State *L, const char* key) override;
-    virtual bool Lua_NewIndex(lua_State *L, const char *key) override;
+    int Lua_Index(lua_State *L, const char* key) override;
+    bool Lua_NewIndex(lua_State *L, const char *key) override;
 };
-
-#endif // _CORE_LUAITEM_H

--- a/src/core/luaitem.h
+++ b/src/core/luaitem.h
@@ -65,6 +65,32 @@ public:
         return false; // TODO: implement this?
     }
 
+    /// Set source filename and source line number for use in debugging and stable ID generation.
+    void setSource(const std::string& filename, const int line)
+    {
+        _sourceFileName = filename;
+        _sourceLine = line;
+    }
+
+    /// Set source filename and source line number for use in debugging and stable ID generation.
+    void setSource(std::string&& filename, const int line)
+    {
+        _sourceFileName = filename;
+        _sourceLine = line;
+    }
+
+    /// Returns the source filename the Lua item was created in, if available.
+    const std::string& getSourceFilename() const
+    {
+        return _sourceFileName;
+    }
+
+    /// Returns the source line number the Lua item was created in, if available.
+    int getSourceLine() const
+    {
+        return _sourceLine;
+    }
+
     nlohmann::json save() const;
     bool load(nlohmann::json& j);
     
@@ -86,6 +112,9 @@ private:
 
     std::string _fullImg; // including pre-applied mods
     std::list<std::string> _extraImgMods; // set via .IconMods, applied on top of .Icon
+
+    std::string _sourceFileName;
+    int _sourceLine = -1;
 
     void parseFullImg(); // convert fullImg + _extraImageMods into _img + _imgMods
 

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -187,7 +187,7 @@ bool Tracker::AddItems(const std::string& file) {
         auto& item = _jsonItems.back();
         item.setID(++_lastItemID);
         item.onChange += {this, [this](void* sender) {
-            JsonItem* i = (JsonItem*)sender;
+            const auto* i = static_cast<JsonItem*>(sender);
             if (!_updatingCache || !_itemChangesDuringCacheUpdate.count(i->getID())) {
                 _providerCountCache.clear();
                 _accessibilityStale = true;
@@ -1034,12 +1034,12 @@ bool Tracker::isVisible(const Location& location)
 
 LuaItem * Tracker::CreateLuaItem()
 {
-    _luaItems.push_back({});
+    _luaItems.emplace_back();
     _objectCache.clear();
     LuaItem& i = _luaItems.back();
     i.setID(++_lastItemID);
     i.onChange += {this, [this](void* sender) {
-        LuaItem* i = (LuaItem*)sender;
+        const auto* i = static_cast<LuaItem*>(sender);
         if (!_updatingCache || !_itemChangesDuringCacheUpdate.count(i->getID())) {
             if (!_bulkUpdate)
                 _providerCountCache.clear();

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -112,6 +112,8 @@ public:
 
     bool changeItemState(const std::string& id, BaseItem::Action action);
 
+    void updateLuaStableIDs();
+
     static void setExecLimit(int execLimit);
     static int getExecLimit();
 
@@ -146,6 +148,8 @@ protected:
              std::vector<std::pair<std::reference_wrapper<const Location>,
                                    std::reference_wrapper<const LocationSection>>>,
              std::less<const LocationSection&>> _sectionRefs;
+
+    std::map<std::string, int> _itemStableNameCounter;
 
     static int _execLimit;
 

--- a/src/core/util.h
+++ b/src/core/util.h
@@ -122,6 +122,21 @@ namespace util {
 #    endif
     }
 #endif
+
+    static uint32_t getStableWeakHash(const char* s)
+    {
+        uint32_t hash = 0;
+        while (*s) hash = (hash << 1) + (hash >> 31) + static_cast<uint8_t>(*(s++));
+        return hash;
+    }
+
+    static uint32_t getStableWeakHash(const std::string& s)
+    {
+        uint32_t hash = 0;
+        for (const auto c: s) hash = (hash << 1) + (hash >> 31) + static_cast<uint8_t>(c);
+        return hash;
+    }
+
 }
 
 #endif // _CORE_UTIL_H

--- a/src/poptracker.cpp
+++ b/src/poptracker.cpp
@@ -1366,6 +1366,7 @@ bool PopTracker::loadTracker(const fs::path& pack, const std::string& variant, b
     // run pack's init script
     printf("Running init...\n");
     bool res = _scriptHost->LoadScript("scripts/init.lua");
+    _tracker->updateLuaStableIDs();
     // save reset-state
     StateManager::saveState(_tracker, _scriptHost, _win->getHints(), json::value_t::null, false, "reset");
     if (loadAutosave) {


### PR DESCRIPTION
Also cleanup of a couple of files.

* For JsonItems (coming from Json files), we use `<type>:<name>`. If there are duplicates, we append `#<N>`. If name is empty, we hash the list of codes instead. This can still result in swapped items if there are multiple "similar" items and load order of json changes.
* For LuaItems (coming from `ScriptHost:CreateLuaItem`), we use `<type>:<initial .Name>@<filename hash>`. If there are duplicates, we append `#<N>`. This can still result in swapped items if either the initial .Name has duplicates and the order of creation is non-deterministic, or if the Item is created after init.lua finished, in which case they won't have stable IDs assigned at the moment.