### PR TITLE
Change "glitched scoutable" to show up as scoutable

### DIFF
--- a/doc/PACKS.md
+++ b/doc/PACKS.md
@@ -503,6 +503,8 @@ Sections can be addressed from Lua with `Tracker:FindObjectForCode("@location_na
 
 `item_size`, `item_width` and `item_height`, since 0.32.0, works the same as with Layouts. See below.
 
+`inspectable_sequence_break` can be set to `true` on either location or section to restore 0.31.0 behavior of showing sequence-break-inspectable as sequence break.
+
 **Tracker Lua Interface:**
 
 * `Tracker:FindObjectForCode('@location_name/section_name')` returns a Section or nil

--- a/schema/packs/locations.json
+++ b/schema/packs/locations.json
@@ -172,6 +172,10 @@
                                     "pattern": "^\\s*[0-9]*\\s*$"
                                 }
                             ]
+                        },
+                        "inspectable_sequence_break": {
+                            "description": "Restores old behavior of showing sequence-break-inspectable locations as sequence break. Inherits from parent if undefined.",
+                            "type": "boolean"
                         }
                     }
                 },
@@ -411,6 +415,10 @@
                     "items": {
                         "$ref": "#/$defs/section"
                     }
+                },
+                "inspectable_sequence_break": {
+                    "description": "Restores old behavior of showing sequence-break-inspectable locations as sequence break. Inherits from parent if undefined.",
+                    "type": "boolean"
                 }
             }
         }

--- a/schema/packs/strict/locations.json
+++ b/schema/packs/strict/locations.json
@@ -131,6 +131,10 @@
                             "description": "Width of the items.",
                             "type": "number",
                             "minimum": 0
+                        },
+                        "inspectable_sequence_break": {
+                            "description": "Restores old behavior of showing sequence-break-inspectable locations as sequence break. Inherits from parent if undefined.",
+                            "type": "boolean"
                         }
                     },
                     "additionalProperties": false
@@ -338,6 +342,10 @@
                     "items": {
                         "$ref": "#/$defs/section"
                     }
+                },
+                "inspectable_sequence_break": {
+                    "description": "Restores old behavior of showing sequence-break-inspectable locations as sequence break. Inherits from parent if undefined.",
+                    "type": "boolean"
                 }
             },
             "additionalProperties": false

--- a/src/core/location.h
+++ b/src/core/location.h
@@ -57,12 +57,16 @@ public:
         const std::list<std::list<std::string>>& getInvisibilityRules() const { return _invisibilityRules; }
     };
 
-    static std::list<Location> FromJSON(nlohmann::json& j,
+    static std::list<Location> FromJSON(
+        nlohmann::json& j,
         const std::list<Location>& parentLookup,
+        bool glitchedScoutableAsGlitched = false,
         const std::list< std::list<std::string> >& parentAccessRules={},
         const std::list< std::list<std::string> >& parentVisibilityRules={},
-        const std::string& parentName="", const std::string& closedImg="",
-        const std::string& openedImg="", const std::string& overlayBackground="");
+        const std::string& closedImg="",
+        const std::string& openedImg="",
+        const std::string& overlayBackground="",
+        const std::string& parentName="");
 
 protected:
     std::string _name;
@@ -72,6 +76,7 @@ protected:
     std::list<LocationSection> _sections;
     std::list< std::list<std::string> > _accessRules; // this is only used if referenced through @-Rules
     std::list< std::list<std::string> > _visibilityRules;
+    bool _glitchedScoutableAsGlitched = false;
 
 public:
     const std::string& getName() const { return _name; }
@@ -84,6 +89,7 @@ public:
     const std::list< std::list<std::string> >& getAccessRules() const { return _accessRules; }
     std::list< std::list<std::string> >& getVisibilityRules() { return _visibilityRules; }
     const std::list< std::list<std::string> >& getVisibilityRules() const { return _visibilityRules; }
+    bool getGlitchedScoutableAsGlitched() const { return _glitchedScoutableAsGlitched; }
     void merge(const Location& other);
 
 #ifndef NDEBUG

--- a/src/core/locationsection.cpp
+++ b/src/core/locationsection.cpp
@@ -43,7 +43,15 @@ std::string_view HighlightToString(const Highlight highlight)
 
 const LuaInterface<LocationSection>::MethodMap LocationSection::Lua_Methods = {};
 
-LocationSection LocationSection::FromJSON(json& j, const std::string& parentId, const std::list< std::list<std::string> >& parentAccessRules, const std::list< std::list<std::string> >& parentVisibilityRules, const std::string& closedImg, const std::string& openedImg, const std::string& overlayBackground)
+LocationSection LocationSection::FromJSON(
+    json& j,
+    const std::string& parentId,
+    const bool glitchedScoutableAsGlitched,
+    const std::list< std::list<std::string> >& parentAccessRules,
+    const std::list< std::list<std::string> >& parentVisibilityRules,
+    const std::string& closedImg,
+    const std::string& openedImg,
+    const std::string& overlayBackground)
 {
     // TODO: pass inherited values as parent instead
     LocationSection sec;
@@ -62,6 +70,7 @@ LocationSection LocationSection::FromJSON(json& j, const std::string& parentId, 
     sec._itemSize = LayoutNode::to_pixel(LayoutNode::to_size(j["item_size"],{-1,-1}));
     sec._itemSize.x = to_int(j["item_width"], sec._itemSize.x);
     sec._itemSize.y = to_int(j["item_height"], sec._itemSize.y);
+    sec._glitchedScoutableAsGlitched = to_bool(j["inspectable_sequence_break"], glitchedScoutableAsGlitched);
 
     if (j["access_rules"].is_array() && !j["access_rules"].empty()) {
         // TODO: merge code with Location's access rules

--- a/src/core/locationsection.h
+++ b/src/core/locationsection.h
@@ -25,12 +25,15 @@ std::string_view HighlightToString(Highlight highlight);
 class LocationSection final : public LuaInterface<LocationSection> {
     friend class LuaInterface;
 public:
-    static LocationSection FromJSON(nlohmann::json& j,
-            const std::string& parentId,
-            const std::list< std::list<std::string> >& parentAccessRules={},
-            const std::list< std::list<std::string> >& parentVisibilityRules={},
-            const std::string& closedImg="", const std::string& openedImg="",
-            const std::string& overlayBackground="");
+    static LocationSection FromJSON(
+        nlohmann::json& j,
+        const std::string& parentId,
+        bool glitchedScoutableAsGlitched = false,
+        const std::list< std::list<std::string> >& parentAccessRules={},
+        const std::list< std::list<std::string> >& parentVisibilityRules={},
+        const std::string& closedImg="",
+        const std::string& openedImg="",
+        const std::string& overlayBackground="");
     Signal<> onChange;
 
 protected:
@@ -46,6 +49,7 @@ protected:
     std::list< std::list<std::string> > _visibilityRules;
     std::string _overlayBackground;
     std::string _ref; // path to actual section if it's just a reference
+    bool _glitchedScoutableAsGlitched = false;
     Highlight _highlight = Highlight::NONE;
     LayoutNode::Size _itemSize;
 
@@ -66,6 +70,7 @@ public:
     const std::string& getParentID() const { return _parentId; }
     std::string getFullID() const { return _parentId + "/" + _name; }
     const std::string& getRef() const { return _ref; }
+    bool getGlitchedScoutableAsGlitched() const { return _glitchedScoutableAsGlitched; }
     Highlight getHighlight() const { return _highlight; }
     const LayoutNode::Size& getItemSize() const { return _itemSize; }
 

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -100,7 +100,7 @@ public:
     AccessibilityLevel isReachable(const Location& location, const LocationSection& section);
     bool isVisible(const Location& location, const LocationSection& section);
     AccessibilityLevel isReachable(const Location& location);
-    AccessibilityLevel isReachable(const LocationSection& location);
+    AccessibilityLevel isReachable(const LocationSection& section);
     bool isVisible(const Location& location);
     bool isVisible(const Location::MapLocation& mapLoc);
 
@@ -153,7 +153,10 @@ protected:
 
     static int _execLimit;
 
-    AccessibilityLevel resolveRules(const std::list< std::list<std::string> >& rules, bool visibilityRules);
+    AccessibilityLevel resolveRules(
+        const std::list< std::list<std::string> >& rules,
+        bool visibilityRules,
+        bool glitchedScoutableAsGlitched);
 
     void rebuildSectionRefs();
     void cacheAccessibility();

--- a/test/core/test_locations_parser.cpp
+++ b/test/core/test_locations_parser.cpp
@@ -19,7 +19,7 @@ TEST(LocationsParserTest, LocationRulesInheritAndEmpty) {
         }
     )"_json;
 
-    auto location = Location::FromJSON(childNode, {}, parentAccessRules, parentVisibilityRules).front();
+    auto location = Location::FromJSON(childNode, {}, false, parentAccessRules, parentVisibilityRules).front();
     EXPECT_EQ(location.getAccessRules(),
               parentAccessRules);
     EXPECT_EQ(location.getVisibilityRules(),


### PR DESCRIPTION
instead of glitched.
Old behavior can be restored per-location or per-section with `"inspectable_sequence_break": true`.
Defaults to true if "target_poptracker_version" <= 0.31.0.