### PR TITLE
Fix shape in strict locations schema

### DIFF
--- a/schema/packs/strict/locations.json
+++ b/schema/packs/strict/locations.json
@@ -260,7 +260,10 @@
                                 "type": "number",
                                 "minimum": -1
                             },
-                            "shape": true,
+                            "shape": {
+                                "description": "Overrides the location shape defined on the map.",
+                                "enum": [null, "rect", "diamond", "trapezoid"]
+                            },
                             "restrict_visibility_rules": {
                                 "example": [
                                     "rule1,rule2",


### PR DESCRIPTION
For some reason shape on the LocationSection was more lax in the strict schema (only checking for existence) so I made them at least match 