### PR TITLE
Makefile: print VersionInfo on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -511,6 +511,10 @@ test: $(EXE) $(TEST_EXE)
 	@echo "Running $(TEST_EXE)"
 	@$(TEST_EXE)
 	@echo "Checking $(EXE)"
+ifdef IS_WIN
+	@echo "VersionInfo: "
+	-@powershell -NoLogo -NoProfile -Command "(Get-Item -Path '$(EXE)').VersionInfo | Format-List -Force"
+endif
 	@echo -n "Size: "
 	@du -h $(EXE) | cut -f -1
 	@echo -n "Version: "


### PR DESCRIPTION
Still looking for the reason we sometimes get
`timeout: failed to run command ‘build/win64/poptracker.exe’: Permission denied` (for RCs)
This prints the  VersionInfo on Windows, if possible, so we can check if it appears to be valid.