### PR TITLE
Update Pokémon RB Pack in community-packs.json

### DIFF
--- a/community-packs.json
+++ b/community-packs.json
@@ -73,12 +73,12 @@
     },
     "pokemonrb_ap": {
         "name": "Pokemon Red/Blue Archipelago Poptracker",
-        "author": "Coveleski & palex00",
+        "author": "palex00",
         "platform": "poptracker",
-        "homepage": "https://github.com/coveleski/rb_tracker",
-        "versions_url": "https://raw.githubusercontent.com/coveleski/rb2/versions/versions.json",
-        "icon_url": "https://raw.githubusercontent.com/coveleski/rb2/main/images/items/itemicon.png",
-        "description":  "Pokemon Red/Blue autotracker pack for PopTracker"
+        "homepage": "https://github.com/palex00/rb_tracker",
+        "versions_url": "https://raw.githubusercontent.com/palex00/rb_tracker/refs/heads/versions/versions.json",
+        "icon_url": "https://raw.githubusercontent.com/palex00/rb_tracker/main/images/items/itemicon.png",
+        "description":  "Pokémon Red & Blue autotracker pack for PopTracker"
     },
     "ape_escape_tracker":{
         "name" : "Ape Escape Tracker",

--- a/community-packs.json
+++ b/community-packs.json
@@ -73,7 +73,7 @@
     },
     "pokemonrb_ap": {
         "name": "Pokemon Red/Blue Archipelago Poptracker",
-        "author": "palex00",
+        "author": "palex00 & Coveleski",
         "platform": "poptracker",
         "homepage": "https://github.com/palex00/rb_tracker",
         "versions_url": "https://raw.githubusercontent.com/palex00/rb_tracker/refs/heads/versions/versions.json",


### PR DESCRIPTION
The previous pack was made by Coveleski and me.

We have since split and I have been ghosted. Coveleski has not been active in any AP server for ~6 months. I do not have control or even edit-access to the old repo. The old repo has several major logic issues that this fork fixes. This fork will also get new features as I am receiving support from GerbilJames and Alchav.

I have also made a PR to the AP-Repo to replace the link there: 
https://github.com/ArchipelagoMW/Archipelago/pull/5122

And will get the link in the pins of the Pokémon-RB channel changed.

Thanks for reading.