### PR TITLE
Change order `[]` and `{}` is checked to allow `{...,[]}`

### DIFF
--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -925,22 +925,21 @@ AccessibilityLevel Tracker::resolveRules(
         for (const auto& rule: ruleset) { //<-- these are all to be ANDed
             if (rule.empty()) continue; // empty/missing code is true
             std::string s = rule;
+            // '{' ... '}' means required to check (i.e. the rule never returns "reachable", but "checkable" instead)
+            if (!s.empty() && s[0] == '{') {
+                inspectOnly = true;
+                s = s.substr(1,s.length()-1);
+            }
+            if (inspectOnly && !s.empty() && s[s.length()-1] == '}') {
+                s = s.substr(0, s.length()-1);
+            }
             // '[' ... ']' means optional/glitches required (different color)
             bool optional = false;
             if (s.length() > 1 && s[0] == '[' && s[s.length()-1]==']') {
                 optional = true;
                 s = s.substr(1,s.length()-2);
             }
-            // '{' ... '}' means required to check (i.e. the rule never returns "reachable", but "checkable" instead)
-            if (s.length() > 1 && s[0] == '{') {
-                inspectOnly = true;
-                s = s.substr(1,s.length()-1);
-            }
-            if (inspectOnly && s.length() > 0 && s[s.length()-1] == '}') {
-                s = s.substr(0, s.length()-1);
-            }
             if (inspectOnly && s.empty()) {
-                inspectOnlyReachable = true;
                 continue;
             }
             // '^$func' gives direct accessibility level rather than an integer code count


### PR DESCRIPTION
Reported here: <https://discord.com/channels/937157230963339364/1385453909933555764>

I believe the reason this wasn't found earlier is because the PopTracker-internal represantation when chaining rules is typically something like `{rule1},[rule2]` or `[rule1].{rule2}` rather than `{rule1,[rule2]}`.