### PR TITLE
CI: update x86_64 workflows to macos-15-intel

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -149,7 +149,7 @@ jobs:
         if-no-files-found: error
 
   build-macos:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     
     steps:
     - name: Install dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -173,7 +173,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release-macos:
-    runs-on: macos-13
+    runs-on: macos-15-intel
 
     steps:
     - name: Install dependencies

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,14 +29,14 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]  # , macos-13  # for tests, only do special macos-13 build below
+        os: [ubuntu-latest, macos-latest]  # for tests on macOS, we do regular arm and special x86_64 below
         shell: [bash]
         extra_make_args: ['']  # default build
         include:
           - os: windows-latest
             shell: msys2 {0}
             extra_make_args: ''
-          - os: macos-13
+          - os: macos-15-intel
             shell: bash
             # we now require 10.15 by default, but 10.13 should work with an extra dependency
             extra_make_args: 'MACOS_DEPLOYMENT_TARGET=10.13'


### PR DESCRIPTION
If we don't change macOS workflows by December, merge this to keep them working. 