### PR TITLE
Fix: always use unix line endings for .pub key files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 *.rc linguist-language=C
+
+# minisign pub keys use LF
+*.pub text eol=lf


### PR DESCRIPTION
this makes using and comparing them more consistent. The Windows builds before this had converted line endings.