### PR TITLE
Clean up Version helper

### DIFF
--- a/src/core/pack.cpp
+++ b/src/core/pack.cpp
@@ -137,8 +137,8 @@ Pack::Pack(const fs::path& path) : _zip(nullptr), _path(path), _override(nullptr
         _name = to_string(_manifest,"name", _uid);
         _gameName = to_string(_manifest,"game_name", _name);
         _versionsURL = to_string(_manifest,"versions_url", "");
-        _minPopTrackerVersion = to_string(_manifest, "min_poptracker_version", "");
-        _targetPopTrackerVersion = to_string(_manifest, "target_poptracker_version", "");
+        _minPopTrackerVersion = Version{to_string(_manifest, "min_poptracker_version", "")};
+        _targetPopTrackerVersion = Version{to_string(_manifest, "target_poptracker_version", "")};
     }
 
     if (!_uid.empty()) {

--- a/src/core/version.h
+++ b/src/core/version.h
@@ -1,16 +1,15 @@
-#ifndef _CORE_VERSION_H
-#define _CORE_VERSION_H
+#pragma once
 
 #include <string>
+
 
 /// Version parser and comparison utility supporting both semver and a[.b[.c[.d]]] notation
 class Version final {
 public:
-    Version(int major, int minor, int revision, const std::string& extra="");
+    Version(int major, int minor, int revision, std::string extra = "");
     Version(int major, int minor, int revision, int extra);
-    Version(const std::string& s);
+    explicit Version(const std::string& s);
     Version();
-    virtual ~Version() = default;
     
     int Major;
     int Minor;
@@ -26,6 +25,3 @@ public:
 private:
     void sanitize();
 };
-
-#endif /* _CORE_VERSION_H */
-

--- a/src/poptracker.cpp
+++ b/src/poptracker.cpp
@@ -412,7 +412,7 @@ bool PopTracker::start()
                                 if (rls["prerelease"].get<bool>() && !includePrerelease)
                                     continue;
                                 version = rls["tag_name"].get<std::string>();
-                                if ((version[0]=='v' || version[0]=='V') && isNewer(version)) {
+                                if ((version[0]=='v' || version[0]=='V') && isNewer(Version{version})) {
                                     version = version.substr(1);
                                     url = rls["html_url"].get<std::string>();
                                     for (auto val: rls["assets"]) {


### PR DESCRIPTION
* Makes conversion from std::string explicit.
* Avoid copy in `int, int, int, std::string` constructor if string is temporary.
* Make all the things const.
* Better naming.