### PR TITLE
Lua: Fix typo in RemoveOnLocationSectionChangedHandler, update docs

### DIFF
--- a/api/lua/definition/poptracker.lua
+++ b/api/lua/definition/poptracker.lua
@@ -20,7 +20,7 @@
 
 ---Currently running PopTracker version as string "x.y.z".
 ---@type string
-PopVersion = "0.33.0"
+PopVersion = "0.33.1"
 -- Actual value comes from the program, not from here, but try to keep in sync with API version here.
 
 ---Set to true or an array of strings to get more error or debug output.
@@ -208,8 +208,18 @@ function ScriptHost:RemoveOnFrameHandler(name) end
 ---@return string reference for RemoveOnLocationSectionChangedHandler
 function ScriptHost:AddOnLocationSectionChangedHandler(name, callback) end
 
----Remove a handler/callback added by AddOnLocationSectionChangedHandler.
+---Old name of RemoveOnLocationSectionChangedHandler.
 ---Available since 0.26.2.
+---Use RemoveOnLocationSectionChangedHandler instead if you support only PopTracker >= 0.33.1.
+---@see ScriptHost.RemoveOnLocationSectionChangedHandler
+---@param name string identifier/name of the handler to remove
+---@return boolean true on success
+function ScriptHost:RemoveOnLocationSectionHandler(name) end
+
+---Remove a handler/callback added by AddOnLocationSectionChangedHandler.
+---Available since 0.33.1.
+---Use RemoveOnLocationSectionHandler instead if you support PopTracker < 0.33.1.
+---@see ScriptHost.RemoveOnLocationSectionHandler
 ---@param name string identifier/name of the handler to remove
 ---@return boolean true on success
 function ScriptHost:RemoveOnLocationSectionChangedHandler(name) end

--- a/doc/PACKS.md
+++ b/doc/PACKS.md
@@ -135,7 +135,8 @@ The following interfaces are provided:
 * `ref :AddOnFrameHandler(name,callback)`: callback(elapsed) will be called every frame, available since 0.25.9
 * `bool :RemoveOnFrameHandler(name)`: remove a frame callback
 * `ref :AddOnLocationSectionChangedHandler(name, callback)`: callback (LocationSection) will be called whenever any location section changes, available since 0.26.2
-* `bool :RemoveOnLocationSectionChangedHandler(name)`: removes a previously added LocationSectionChanged callback, available since 0.26.2
+* `bool :RemoveOnLocationSectionChangedHandler(name)`: removes a previously added LocationSectionChanged callback, available since 0.33.1
+* `bool :RemoveOnLocationSectionHandler(name)`: Old name of RemoveOnLocationSectionChangedHandler, available since 0.26.2
 * `ThreadProxy :RunScriptAsync(luaFilename, arg, completeCallback, progressCallback)`: Load and run script in a separate thread. `arg` is passed as global arg. Most other things are not available in the new context. Use `return` to return a value from the script, that will be passed to `callback(result)`. (ThreadProxy has no function yet)
 * `ThreadProxy :RunStringAsync(script, arg, completeCallback, progressCallback)`: same as RunScriptAsync, but script is a string instead of a filename.
 * `void :AsyncProgress(arg)`: call progressCallback in main context on next frame. Arg is passed to callback.

--- a/src/core/scripthost.cpp
+++ b/src/core/scripthost.cpp
@@ -25,6 +25,7 @@ const LuaInterface<ScriptHost>::MethodMap ScriptHost::Lua_Methods = {
     LUA_METHOD(ScriptHost, AddOnFrameHandler, const char*, LuaRef),
     LUA_METHOD(ScriptHost, RemoveOnFrameHandler, const char*),
     LUA_METHOD(ScriptHost, AddOnLocationSectionChangedHandler, const char*, LuaRef),
+    LUA_METHOD(ScriptHost, RemoveOnLocationSectionChangedHandler, const char*),
     LUA_METHOD(ScriptHost, RemoveOnLocationSectionHandler, const char*),
     LUA_METHOD(ScriptHost, RunScriptAsync, const char*, json, LuaRef, LuaRef),
     LUA_METHOD(ScriptHost, RunStringAsync, const char*, json, LuaRef, LuaRef),
@@ -408,14 +409,14 @@ bool ScriptHost::RemoveOnFrameHandler(const std::string& name)
 
 const std::string& ScriptHost::AddOnLocationSectionChangedHandler(const std::string& name, LuaRef callback)
 {
-    RemoveOnLocationSectionHandler(name);
+    RemoveOnLocationSectionChangedHandler(name);
     if (!callback.valid())
         luaL_error(_L, "Invalid callback");
     _onLocationSectionChangedHandlers.push_back({callback.ref, name});
     return _onLocationSectionChangedHandlers.back().name;
 }
 
-bool ScriptHost::RemoveOnLocationSectionHandler(const std::string &name)
+bool ScriptHost::RemoveOnLocationSectionChangedHandler(const std::string &name)
 {
     for (auto it = _onLocationSectionChangedHandlers.begin(); it != _onLocationSectionChangedHandlers.end(); ++it) {
         if (it->name == name) {
@@ -425,6 +426,11 @@ bool ScriptHost::RemoveOnLocationSectionHandler(const std::string &name)
         }
     }
     return false;
+}
+
+bool ScriptHost::RemoveOnLocationSectionHandler(const std::string &name)
+{
+    return RemoveOnLocationSectionChangedHandler(name);
 }
 
 json ScriptHost::RunScriptAsync(const std::string& file, const json& arg, LuaRef completeCallback, LuaRef progressCallback)

--- a/src/core/scripthost.h
+++ b/src/core/scripthost.h
@@ -78,6 +78,7 @@ public:
     std::string AddOnFrameHandler(const std::string& name, LuaRef callback);
     bool RemoveOnFrameHandler(const std::string& name);
     const std::string& AddOnLocationSectionChangedHandler(const std::string& name, LuaRef callback);
+    bool RemoveOnLocationSectionChangedHandler(const std::string& name);
     bool RemoveOnLocationSectionHandler(const std::string& name);
     json RunScriptAsync(const std::string& file, const json& arg, LuaRef completeCallback, LuaRef progressCallback);
     json RunStringAsync(const std::string& script, const json& arg, LuaRef completeCallback, LuaRef progressCallback);


### PR DESCRIPTION
RemoveOnLocationSectionChangedHandler was previously called RemoveOnLocationSectionHandler in code, but not in docs. For 0.33.1, both names are supported and docs/api are updated.