### PR TITLE
Add missing IconMods entry to Lua API

### DIFF
--- a/api/lua/definition/poptracker.lua
+++ b/api/lua/definition/poptracker.lua
@@ -521,6 +521,10 @@ LuaItem.Name = ""
 ---@type ImageRef?
 LuaItem.Icon = nil
 
+---Icon modifier, see JSON's img_mods. Only available in PopTracker, since 0.11.0.
+---@type string
+LuaItem.IconMods = ""
+
 ---Optional container to store item's state. Keys have to be string for `:Get` and `:Set` to work.
 ---@type table?
 LuaItem.ItemState = nil


### PR DESCRIPTION
Added `LuaItem.IconMods` to the Lua API. It was listed in PACKS.md and functional, but not in the API itself, so at the request of Black Silver I've added it.