### PR TITLE
CI: pin most github github actions to absolute version

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -47,7 +47,7 @@ jobs:
       run: |
         sudo apt-get update -y -qq
         sudo apt-get install coreutils build-essential libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev p7zip libgtest-dev libgmock-dev
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
       with:
         submodules: recursive
     - name: Build RELEASE
@@ -68,7 +68,7 @@ jobs:
           build/linux-x86_64/poptracker
           dist/*
     - name: Store DIST
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: ubuntu-22-04-dist
         path: dist
@@ -81,7 +81,7 @@ jobs:
       run: |
         sudo apt-get update -y -qq
         sudo apt-get install coreutils build-essential libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev p7zip wget libgtest-dev libgmock-dev
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
       with:
         submodules: recursive
     - name: Get appimage-builder, appimagetool, runtime, AppRun and hooks
@@ -142,7 +142,7 @@ jobs:
           appimage-build/linux-x86_64/poptracker
           *.AppImage*
     - name: Store AppImage
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: AppImage
         path: "*.AppImage*"
@@ -155,11 +155,11 @@ jobs:
     - name: Install dependencies
       run: |
         brew install coreutils SDL2 sdl2_ttf sdl2_image openssl@3.0 automake libtool autoconf googletest || true
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
       with:
         submodules: recursive
     - name: Cache/restore macosx-libs
-      uses: actions/cache@v4
+      uses: actions/cache@v5.0.3
       with:
         key: libs-${{ runner.os }}-${{ runner.arch }}-${{ env.cache-name }}-${{ hashFiles('macosx/*.sh') }}
         path: |
@@ -190,12 +190,12 @@ jobs:
           build/darwin-x86_64/poptracker.app/Contents/MacOS/poptracker
           dist/*
     - name: Store app bundle
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: ${{ env.POP_NAME }}_macos
         path: build/darwin-x86_64/poptracker.app
     - name: Store ZIP/DMG
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: macos-dist
         path: dist
@@ -223,11 +223,11 @@ jobs:
           p7zip
           wget
           mingw-w64-x86_64-advancecomp
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
       with:
         submodules: recursive
     - name: Cache/restore win32-libs
-      uses: actions/cache@v4
+      uses: actions/cache@v5.0.3
       with:
         key: libs-${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('win32/*.sh') }}
         path: |
@@ -277,7 +277,7 @@ jobs:
           build/win64/poptracker.exe
           dist/*
     - name: Store DIST
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: win64-msys-dist
         path: dist
@@ -295,7 +295,7 @@ jobs:
           build/win64/poptracker.exe
           dist/poptracker-win64-debug.zip
     - name: Store DEBUG
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: win64-msys-debug
         path: dist/poptracker-win64-debug.zip

--- a/.github/workflows/check-examples.yaml
+++ b/.github/workflows/check-examples.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           submodules: recursive
 

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Find typos
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
     - uses: codespell-project/actions-codespell@v2
       with:
         check_filenames: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
     - name: Set env
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
       with:
         submodules: recursive
     - name: Package source
@@ -61,7 +61,7 @@ jobs:
       run: |
         sudo apt-get update -y -qq
         sudo apt-get install coreutils build-essential libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev p7zip wget libgtest-dev libgmock-dev
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
       with:
         submodules: recursive
     - name: Set env
@@ -144,7 +144,7 @@ jobs:
       run: |
         sudo apt-get update -y -qq
         sudo apt-get install coreutils build-essential libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev p7zip wget libgtest-dev libgmock-dev
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
       with:
         submodules: recursive
     - name: Set env
@@ -179,7 +179,7 @@ jobs:
     - name: Install dependencies
       run: |
         brew install coreutils SDL2 sdl2_ttf sdl2_image openssl@3.0 automake libtool autoconf googletest || true
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
       with:
         submodules: recursive
     - name: Set env
@@ -230,7 +230,7 @@ jobs:
           p7zip
           wget
           mingw-w64-x86_64-advancecomp
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
       with:
         submodules: recursive
     - name: Build libs

--- a/.github/workflows/scan-build.yaml
+++ b/.github/workflows/scan-build.yaml
@@ -49,7 +49,7 @@ jobs:
         shell: ${{ matrix.shell }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           submodules: recursive
       - name: Install dependencies (apt)
@@ -91,7 +91,7 @@ jobs:
             make -j4
       - name: Store report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6.0.0
         with:
           name: scan-build-reports-${{ matrix.os }}
           path: scan-build-reports

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -80,7 +80,7 @@ jobs:
           mingw64/mingw-w64-x86_64-openssl
           mingw64/mingw-w64-x86_64-gtest
           p7zip
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
       with:
         submodules: recursive
     - name: Configure ASAN (macos-latest)
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
       with:
         submodules: recursive
     - uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15

--- a/.github/workflows/update-cacert.yaml
+++ b/.github/workflows/update-cacert.yaml
@@ -13,7 +13,7 @@ jobs:
   update-cacert:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Check for cacert update
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hopefully those are immutable already, or will become immutable in the future. It's nicer than putting the commit SHA everywhere.