### PR TITLE
Fix version comparison in `Pack::Find` and `Pack::ListAvailable`

### DIFF
--- a/src/core/pack.cpp
+++ b/src/core/pack.cpp
@@ -1,6 +1,7 @@
 #include "pack.h"
 #include "fileutil.h"
 #include "jsonutil.h"
+#include "version.h"
 #include <dirent.h>
 #include <stdlib.h>
 #include "sha256.h"
@@ -421,10 +422,7 @@ std::vector<Pack::Info> Pack::ListAvailable()
             return true;
         if (n>0)
             return false;
-        int m = strcasecmp(lhs.version.c_str(), rhs.version.c_str());
-        if (m<0)
-            return true;
-        return false;
+        return Version(lhs.version) < Version(rhs.version);
     });
 
     return res;
@@ -457,8 +455,7 @@ Pack::Info Pack::Find(const std::string& uid, const std::string& version, const 
     if (!packs.empty()) {
         // fall back to latest version since an upgrade may have removed it
         std::sort(packs.begin(), packs.end(), [](const Pack::Info& lhs, const Pack::Info& rhs) {
-            int m = strcasecmp(lhs.version.c_str(), rhs.version.c_str());
-            return (m<0);
+            return Version(lhs.version) < Version(rhs.version);
         });
         return packs.back();
     }


### PR DESCRIPTION
Both functions used `strcasecmp` to compare version strings which works most of the time until it doesn't. This caused packs with version 0.3 to be sorted before 0.10. There's already a proper Version class in the project that supports comparison so use that instead.

Before:

```
> poptracker --list-packs

ap_crystal_palex00 0.10.1 "Pokémon Crystal Archipelago"
ap_crystal_palex00 0.9.10 "Pokémon Crystal Archipelago"

> poptracker --load-pack ap_crystal_palex00

found pack "/home/eijebong/PopTracker/packs/ap_crystal_0.9.10.zip"
Loading Tracker /home/eijebong/PopTracker/packs/ap_crystal_0.9.10.zip:!
```

After:

```
> poptracker --list-packs

ap_crystal_palex00 0.9.10 "Pokémon Crystal Archipelago"
ap_crystal_palex00 0.10.1 "Pokémon Crystal Archipelago"

> poptracker --load-pack ap_crystal_palex00

found pack "/home/eijebong/PopTracker/packs/ap_crystal_palex00_0.10.1.zip"
Loading Tracker /home/eijebong/PopTracker/packs/ap_crystal_palex00_0.10.1.zip:!
```