### PR TITLE
Update optional libpng to v1.6.55

### DIFF
--- a/macosx/build_thirdparty.sh
+++ b/macosx/build_thirdparty.sh
@@ -59,7 +59,7 @@ LIB_OPENSSL_URL="https://github.com/openssl/openssl.git"
 LIB_SDL_TAG="release-2.32.10"
 LIB_SDL_IMAGE_TAG="release-2.8.8"
 LIB_SDL_TTF_TAG="release-2.24.0"
-LIB_PNG_TAG="v1.6.54"
+LIB_PNG_TAG="v1.6.55"
 LIB_FREETYPE_TAG="VER-2-13-3"
 LIB_OPENSSL_TAG="openssl-3.0.19"
 


### PR DESCRIPTION
(This basically only tracks the latest version that should work/was tested in case we ever need to ship libpng directly again.)