### PR TITLE
Fix: defer MapTooltip update

### DIFF
--- a/src/ui/trackerview.h
+++ b/src/ui/trackerview.h
@@ -66,6 +66,7 @@ protected:
     std::map<std::string, std::list<Item*>> _items;
     std::map<std::string, std::list<MapWidget*>> _maps;
     bool _mapsDirty = false;
+    bool _mapTooltipDirty = false;
     std::list<Tabs*> _tabs;
     std::list<std::string> _activeTabs;
     std::list< std::pair<std::string,std::string> > _missedHints;
@@ -84,6 +85,7 @@ protected:
     void updateLocation(const std::string& location);
     void updateLocationNow(const std::string& location);
     void updateMapTooltip();
+    void updateMapTooltipNow();
     void updateItem(Item* w, const BaseItem& item);
 
     size_t addLayoutNodes(Container* container, const std::list<LayoutNode>& nodes, size_t depth=0);


### PR DESCRIPTION
since AvailableChestCount invalidates logic now,
there are packs that absolutely need deferred logic for MapTooltips now as well to function.