### PR TITLE
Fix AppUpdater to not consider assets of non-installable latest

### DIFF
--- a/src/appupdater/appupdater.cpp
+++ b/src/appupdater/appupdater.cpp
@@ -101,98 +101,120 @@ void AppUpdater::checkForUpdate()
     );
 }
 
-void AppUpdater::releasesResponse(const std::string &content)
+std::optional<AppUpdater::Update> AppUpdater::updateFromResponse(const std::string& content) const
 {
-    try {
-        std::string altVersionStr;
-        std::string versionStr;
-        std::vector<gh::api::ReleaseAsset> assets;
-        std::string browserUrl;
-        std::string altBrowserUrl;
-        bool newerVersionExists = false;
-        for (const auto& rls: gh::api::Releases(content)) {
-            if ((rls.tagName()[0] != 'v' && rls.tagName()[0] != 'V') || sanitize_print(rls.tagName()) != rls.tagName())
-                continue; // unexpected tag
-            versionStr = rls.tagName().substr(1);
-            const auto v = Version{versionStr};
-            if (!isNewer(v) || (rls.prerelease() && !_includePrerelease && !isSameBaseVersion(v))) {
-                // not an update
-                versionStr.clear();
+    std::string altVersionStr;
+    std::string versionStr;
+    std::vector<gh::api::ReleaseAsset> assets;
+    std::string browserUrl;
+    std::string altBrowserUrl;
+    bool newerVersionExists = false;
+    for (const auto& rls: gh::api::Releases(content)) {
+        if ((rls.tagName()[0] != 'v' && rls.tagName()[0] != 'V') || sanitize_print(rls.tagName()) != rls.tagName())
+            continue; // unexpected tag
+        versionStr = rls.tagName().substr(1);
+        const auto v = Version{versionStr};
+        if (!isNewer(v) || (rls.prerelease() && !_includePrerelease && !isSameBaseVersion(v))) {
+            // not an update
+            versionStr.clear();
+            continue;
+        }
+        browserUrl = rls.htmlUrl();
+        newerVersionExists = true;
+        for (const auto& asset: rls.assets()) {
+            // collect signed assets
+            if (asset.nameEndsWithCI(".minisig"))
                 continue;
-            }
-            browserUrl = rls.htmlUrl();
-            newerVersionExists = true;
-            for (const auto& asset: rls.assets()) {
-                // collect signed assets
-                if (asset.nameEndsWithCI(".minisig"))
-                    continue;
-                if (!rls.hasAssetUrl(asset.browserDownloadUrl() + ".minisig"))
-                    continue;
-                assets.push_back(asset);
-            }
-            if (assets.empty()) {
-                versionStr.clear();
+            if (!rls.hasAssetUrl(asset.browserDownloadUrl() + ".minisig"))
                 continue;
-            }
-            fs::path pubKeyDir = fs::app_path() / "key";
-            if (!fs::is_directory(pubKeyDir))
-                pubKeyDir = fs::current_path() / "key";
-            bool foundKey = false;
-            for (auto& entry: fs::directory_iterator(pubKeyDir)) {
-                if (entry.is_regular_file()) {
-                    if (rls.bodyContains(entry.path().filename())) {
-                        foundKey = true;
-                        break; // found an installable update
-                    }
-                    std::string keyData;
-                    if (readFile(entry.path(), keyData)) {
-                        const auto p1 = keyData.find('\n');
-                        if (p1 != std::string::npos) {
-                            const auto p2 = keyData.find_first_of("\r\n", p1 + 1);
-                            keyData = keyData.substr(
-                                p1 + 1,
-                                p2 == std::string::npos ? std::string::npos : (p2 - p1 - 1)
-                            );
-                            if (rls.bodyContains(keyData)) {
-                                foundKey = true;
-                                break; // found an installable update
-                            }
+            assets.push_back(asset);
+        }
+        if (assets.empty()) {
+            versionStr.clear();
+            continue;
+        }
+        fs::path pubKeyDir = fs::app_path() / "key";
+        if (!fs::is_directory(pubKeyDir))
+            pubKeyDir = fs::current_path() / "key";
+        bool foundKey = false;
+        for (auto& entry: fs::directory_iterator(pubKeyDir)) {
+            if (entry.is_regular_file()) {
+                if (rls.bodyContains(entry.path().filename())) {
+                    foundKey = true;
+                    break; // found an installable update
+                }
+                std::string keyData;
+                if (readFile(entry.path(), keyData)) {
+                    const auto p1 = keyData.find('\n');
+                    if (p1 != std::string::npos) {
+                        const auto p2 = keyData.find_first_of("\r\n", p1 + 1);
+                        keyData = keyData.substr(
+                            p1 + 1,
+                            p2 == std::string::npos ? std::string::npos : (p2 - p1 - 1)
+                        );
+                        if (rls.bodyContains(keyData)) {
+                            foundKey = true;
+                            break; // found an installable update
                         }
                     }
                 }
             }
-            if (foundKey)
-                break; // found an update
-            // remember update that can be downloaded, but can't be verified/auto-installed
-            if (altVersionStr.empty()) {
-                altVersionStr = std::move(versionStr);
-                versionStr.clear();
-                altBrowserUrl = std::move(browserUrl);
-            }
         }
-        if (!versionStr.empty())
-            updateAvailable(versionStr, browserUrl, assets);
-        else if (!altVersionStr.empty()) // TODO: also check if primary pub key expired
-            updateAvailable(altVersionStr, altBrowserUrl, {});
-        else if (newerVersionExists)
+        if (foundKey)
+            break; // found an update
+        // remember update that can be downloaded, but can't be verified/auto-installed
+        if (altVersionStr.empty()) {
+            altVersionStr = std::move(versionStr);
+            versionStr.clear();
+            altBrowserUrl = std::move(browserUrl);
+            browserUrl.clear();
+        }
+    }
+    // no newer version available
+    if (!newerVersionExists)
+        return {};
+    // an update we can auto-update to is available (on platforms where auto-updater exists)
+    if (!versionStr.empty())
+        return {Update{
+            std::move(versionStr),
+            std::move(browserUrl),
+            std::move(assets),
+        }};
+    // update is available, but we can't auto-updating to it (on platforms where auto-updater exists)
+    if (!altVersionStr.empty())
+        return {Update{
+            std::move(altVersionStr),
+            std::move(altBrowserUrl),
+            {},
+        }};
+    // if we get here, there is an update, but we do not support it
+    return {Update{}};
+}
+
+void AppUpdater::releasesResponse(const std::string &content)
+{
+    try {
+        std::optional<Update> update = updateFromResponse(content);
+        if (!update.has_value())
+            printf("Update: already up to date\n");
+        else if (update->versionStr.empty())
             printf("Update: no candidate for installation\n");
         else
-            printf("Update: already up to date\n");
+            updateAvailable(*update);
     } catch (...) {
         fprintf(stderr, "Update: error parsing json\n");
     }
 }
 
-void AppUpdater::updateAvailable(const std::string& version, const std::string& url,
-    const std::vector<gh::api::ReleaseAsset>& assets)
+void AppUpdater::updateAvailable(const Update& update)
 {
     std::string ignoreData;
     json ignore;
     if (readFile(_ignoreVersionsPath, ignoreData)) {
         ignore = parse_jsonc(ignoreData);
         if (ignore.is_array()) {
-            if (std::find(ignore.begin(), ignore.end(), version) != ignore.end()) {
-                printf("Update: %s is in ignore list\n", version.c_str());
+            if (std::find(ignore.begin(), ignore.end(), update.versionStr) != ignore.end()) {
+                printf("Update: %s is in ignore list\n", update.versionStr.c_str());
                 return;
             }
         } else {
@@ -208,12 +230,12 @@ void AppUpdater::updateAvailable(const std::string& version, const std::string& 
     constexpr std::string_view updatePattern; // none
 #endif
 
-    const auto autoUpdateIt = std::find_if(assets.begin(), assets.end(), [updatePattern](const auto& asset) {
+    const auto assetIt = std::find_if(update.assets.begin(), update.assets.end(), [updatePattern](const auto& asset) {
         const auto& download = asset.browserDownloadUrl();
         return !updatePattern.empty() && download.length() > updatePattern.length()
             && download.rfind(updatePattern, download.length() - updatePattern.length()) != std::string::npos;
     });
-    const bool hasAutoUpdate = autoUpdateIt != assets.end();
+    const bool hasAutoUpdate = assetIt != update.assets.end();
 
 #ifdef _WIN32
     auto updater = hasAutoUpdate ? (fs::app_path() / "PopUpdater.exe") : "";
@@ -257,37 +279,37 @@ void AppUpdater::updateAvailable(const std::string& version, const std::string& 
     }
 
     std::string msg;
-    if (assets.empty()) {
-        msg = "Update to PopTracker " + version + " available, that can't be verified. Download?";
+    if (update.assets.empty()) {
+        msg = "Update to PopTracker " + update.versionStr + " available, that can't be verified. Download?";
 #ifdef _WIN32
     } else if (!updater.empty()) {
 #else
     } else if (userWritable && !updater.empty()) {
         // we currently only support elevating privileges on Windows
 #endif
-        msg = "Update to PopTracker " + version + " available. Download and install?";
+        msg = "Update to PopTracker " + update.versionStr + " available. Download and install?";
     } else {
-        msg = "Update to PopTracker " + version + " available. Download?";
+        msg = "Update to PopTracker " + update.versionStr + " available. Download?";
     }
     if (Dlg::MsgBox("PopTracker", msg, Dlg::Buttons::YesNo, Dlg::Icon::Question) == Dlg::Result::Yes)
     {
         if (!updater.empty()) {
             installUpdate(
-                autoUpdateIt->browserDownloadUrl(),
+                assetIt->browserDownloadUrl(),
                 updater,
                 !userWritable,
-                autoUpdateIt->updatedAt(),
-                url);
+                assetIt->updatedAt(),
+                update.browserUrl);
             return;
         }
-        openWebsite(url);
+        openWebsite(update.browserUrl);
     }
     else {
-        msg = "Skip version " + version + "?";
+        msg = "Skip version " + update.versionStr + "?";
         if (Dlg::MsgBox("PopTracker", msg, Dlg::Buttons::YesNo, Dlg::Icon::Question) == Dlg::Result::Yes)
         {
-            printf("Update: ignoring %s\n", version.c_str());
-            ignore.push_back(version);
+            printf("Update: ignoring %s\n", update.versionStr.c_str());
+            ignore.push_back(update.versionStr);
             writeFile(_ignoreVersionsPath, ignore.dump(0));
         }
     }

--- a/src/appupdater/appupdater.cpp
+++ b/src/appupdater/appupdater.cpp
@@ -169,6 +169,7 @@ std::optional<AppUpdater::Update> AppUpdater::updateFromResponse(const std::stri
             altBrowserUrl = std::move(browserUrl);
             browserUrl.clear();
         }
+        assets.clear();
     }
     // no newer version available
     if (!newerVersionExists)

--- a/src/appupdater/appupdater.hpp
+++ b/src/appupdater/appupdater.hpp
@@ -12,7 +12,7 @@
 
 
 namespace pop {
-    class AppUpdater final : HTTPCache {
+    class AppUpdater : HTTPCache {
     public:
         using json = nlohmann::json;
 
@@ -33,12 +33,20 @@ namespace pop {
         Signal<> onInstallStarted;
         Signal<const std::string&, const std::string&> onUpdateFailed;
 
+    protected:
+        struct Update {
+            std::string versionStr;
+            std::string browserUrl;
+            std::vector<gh::api::ReleaseAsset> assets;
+        };
+
+        std::optional<Update> updateFromResponse(const std::string& content) const;
+
     private:
         /// Handle OK response of app update check
         void releasesResponse(const std::string &content);
         /// Notification that an app update is available
-        void updateAvailable(const std::string& version, const std::string& url,
-            const std::vector<gh::api::ReleaseAsset>& assets);
+        void updateAvailable(const Update& update);
         /// Download and install an app update
         void installUpdate(const std::string& url, const fs::path& updater, bool asAdmin, uint64_t timestamp,
             const std::string& browserUrl="");

--- a/test/appupdater/test_parser.cpp
+++ b/test/appupdater/test_parser.cpp
@@ -1,0 +1,303 @@
+// tests parsing the update info from JSON responses
+
+#include <gtest/gtest.h>
+
+#include "../../lib/asio/include/asio/io_service.hpp"
+#include "../../src/poptracker.h"
+#include "../../src/appupdater/appupdater.hpp"
+#include "../util/tempdir.hpp"
+
+
+static asio::io_service ioService;
+static TempDir tempDir;
+
+static const std::string currentTag = std::string("v") + PopTracker::VERSION_STRING;
+static const std::string validPubKeyBody = "Public key: `RWR/KVOoufNpOxFX4VZUW/gDaRnlr5tJkRIHNIvaC0qxbbYPTxOX22q9`";
+const std::string owner = "black-sliver";
+const std::string repo = "PopTracker";
+const std::string baseUrl = "https://github.com/" + owner + "/" + repo + "/releases/download/";
+const std::string currentTagUrl = baseUrl + currentTag + "/";
+
+
+/// Fixture to run tests for both included and excluded prereleases via GetParam().
+class AppUpdaterParseTest : public pop::AppUpdater, public testing::TestWithParam<bool> {
+protected:
+    AppUpdaterParseTest()
+    : AppUpdater(ioService, {}, owner, repo, GetParam(),
+        tempDir.tempPath(), tempDir.tempPath())
+    {
+    }
+};
+
+
+TEST_P(AppUpdaterParseTest, EmptyString)
+{
+    EXPECT_ANY_THROW({
+        updateFromResponse("");
+    });
+}
+
+TEST_P(AppUpdaterParseTest, InvalidJson)
+{
+    EXPECT_ANY_THROW({
+        updateFromResponse("[");
+    });
+}
+
+TEST_P(AppUpdaterParseTest, NotArray)
+{
+    EXPECT_ANY_THROW({
+        updateFromResponse("{}");
+    });
+}
+
+TEST_P(AppUpdaterParseTest, EmptyArray)
+{
+    EXPECT_FALSE(updateFromResponse("[]").has_value());
+}
+
+static std::string createDownloadUrl(const std::string& name, const std::string& tag)
+{
+    return baseUrl + tag + "/" + name;
+}
+
+static nlohmann::json createAsset(const std::string& name, const std::string& tag, std::string_view updatedAt)
+{
+    return {
+        {"name", name},
+        {"browser_download_url", createDownloadUrl(name, tag)},
+        {"updated_at", updatedAt},
+    };
+}
+
+TEST_P(AppUpdaterParseTest, AlreadyLatest)
+{
+    const std::string updatedAt = "2026-04-03T08:29:48Z";
+    constexpr bool prerelease = false;
+    const std::string assetName = "PopTracker-0.35.0-x86_64.AppImage";
+    const std::string s = json{
+        {
+            {"html_url", "..."},
+            {"body", validPubKeyBody},
+            {"tag_name", currentTag},
+            {"prerelease", prerelease},
+            {"updated_at", updatedAt},
+            {"assets", {
+                createAsset(assetName, currentTag, updatedAt),
+                createAsset(assetName + ".minisig", currentTag, updatedAt),
+            }}
+        }
+    }.dump();
+
+    EXPECT_FALSE(updateFromResponse(s).has_value());
+}
+
+TEST_P(AppUpdaterParseTest, ReleaseAvailable)
+{
+    const std::string newerVersion = "9999.99.99";
+    const std::string newerTag = "v" + newerVersion;
+    const std::string updatedAt = "2026-04-03T08:29:48Z";
+    constexpr bool prerelease = false;
+    const std::string assetName = "PopTracker-" + newerVersion + "-x86_64.AppImage";
+    const std::string s = json{
+        {
+            {"html_url", "..."},
+            {"body", validPubKeyBody},
+            {"tag_name", newerTag},
+            {"prerelease", prerelease},
+            {"updated_at", updatedAt},
+            {"assets", {
+                createAsset(assetName, newerTag, updatedAt),
+                createAsset(assetName + ".minisig", newerTag, updatedAt),
+            }}
+        }
+    }.dump();
+
+    const auto update = updateFromResponse(s);
+    ASSERT_TRUE(update.has_value());
+    EXPECT_EQ(update->versionStr, newerVersion);
+    EXPECT_FALSE(update->browserUrl.empty());
+    EXPECT_FALSE(update->assets.empty());
+}
+
+TEST_P(AppUpdaterParseTest, PrereleaseAvailable)
+{
+    const std::string newerVersion = "9999.99.99-rc1";
+    const std::string newerTag = "v" + newerVersion;
+    const std::string updatedAt = "2026-04-03T08:29:48Z";
+    constexpr bool prerelease = true;
+    const std::string assetName = "PopTracker-" + newerVersion + "-x86_64.AppImage";
+    const std::string s = json{
+        {
+            {"html_url", "..."},
+            {"body", validPubKeyBody},
+            {"tag_name", newerTag},
+            {"prerelease", prerelease},
+            {"updated_at", updatedAt},
+            {"assets", {
+                createAsset(assetName, newerTag, updatedAt),
+                createAsset(assetName + ".minisig", newerTag, updatedAt),
+            }}
+        }
+    }.dump();
+
+    const auto update = updateFromResponse(s);
+    ASSERT_EQ(update.has_value(), GetParam());
+    if (GetParam()) {
+        EXPECT_EQ(update->versionStr, newerVersion);
+        EXPECT_FALSE(update->browserUrl.empty());
+        EXPECT_FALSE(update->assets.empty());
+    }
+}
+
+// TODO: also test RC1 -> RC2 update even if prereleases are excluded, but this requires injection of current version
+
+TEST_P(AppUpdaterParseTest, NotCompatible)
+{
+    const std::string newerVersion = "9999.99.99";
+    const std::string newerTag = "v" + newerVersion;
+    const std::string updatedAt = "2026-04-03T08:29:48Z";
+    constexpr bool prerelease = false;
+    const std::string s = json{
+        {
+            {"html_url", "..."},
+            {"body", validPubKeyBody},
+            {"tag_name", newerTag},
+            {"prerelease", prerelease},
+            {"updated_at", updatedAt},
+            {"assets", json::array()}
+        }
+    }.dump();
+
+    const auto update = updateFromResponse(s);
+    ASSERT_TRUE(update.has_value());
+    EXPECT_TRUE(update->versionStr.empty());
+    EXPECT_TRUE(update->browserUrl.empty()); // url empty if update is not compatible
+    EXPECT_TRUE(update->assets.empty());
+}
+
+TEST_P(AppUpdaterParseTest, NotAutoInstallable)
+{
+    const std::string newerVersion = "9999.99.99";
+    const std::string newerTag = "v" + newerVersion;
+    const std::string updatedAt = "2026-04-03T08:29:48Z";
+    constexpr bool prerelease = false;
+    const std::string assetName = "PopTracker-" + newerVersion + "-x86_64.AppImage";
+    const std::string s = json{
+        {
+            {"html_url", "..."},
+            {"body", ""},
+            {"tag_name", newerTag},
+            {"prerelease", prerelease},
+            {"updated_at", updatedAt},
+            {"assets", {
+                createAsset(assetName, newerTag, updatedAt),
+                createAsset(assetName + ".minisig", newerTag, updatedAt),
+            }}
+        }
+    }.dump();
+
+    const auto update = updateFromResponse(s);
+    ASSERT_TRUE(update.has_value());
+    EXPECT_EQ(update->versionStr, newerVersion);
+    EXPECT_FALSE(update->browserUrl.empty());
+    EXPECT_TRUE(update->assets.empty()); // assets empty if update can't be auto-installed
+}
+
+TEST_P(AppUpdaterParseTest, ReleaseAndPrerelease)
+{
+    const std::string newerVersion = "9999.99.98";
+    const std::string evenNewerVersion = "9999.99.99-rc1";
+    const std::string newerTag = "v" + newerVersion;
+    const std::string evenNewerTag = "v" + evenNewerVersion;
+    const std::string updatedAt = "2026-04-03T08:29:48Z";
+    constexpr bool newerPrerelease = false;
+    constexpr bool evenNewerPrerelease = true;
+    const std::string newerAssetName = "PopTracker-" + newerVersion + "-x86_64.AppImage";
+    const std::string evenNewerAssetName = "PopTracker-" + evenNewerVersion + "-x86_64.AppImage";
+    const std::string newerBrowserUrl = "1"; // is not validated
+    const std::string evenNewerBrowserUrl = "2";
+    const std::string s = json{
+        {
+            {"html_url", evenNewerBrowserUrl},
+            {"body", validPubKeyBody},
+            {"tag_name", evenNewerTag},
+            {"prerelease", evenNewerPrerelease},
+            {"updated_at", updatedAt},
+            {"assets", {
+                createAsset(evenNewerAssetName, evenNewerTag, updatedAt),
+                createAsset(evenNewerAssetName + ".minisig", evenNewerTag, updatedAt),
+            }}
+        },
+        {
+            {"html_url", newerBrowserUrl},
+            {"body", validPubKeyBody},
+            {"tag_name", newerTag},
+            {"prerelease", newerPrerelease},
+            {"updated_at", updatedAt},
+            {"assets", {
+                createAsset(newerAssetName, newerTag, updatedAt),
+                createAsset(newerAssetName + ".minisig", newerTag, updatedAt),
+            }}
+        }
+    }.dump();
+
+    const auto update = updateFromResponse(s);
+    ASSERT_TRUE(update.has_value());
+    if (GetParam()) {
+        EXPECT_EQ(update->versionStr, evenNewerVersion);
+        EXPECT_EQ(update->browserUrl, evenNewerBrowserUrl);
+        EXPECT_EQ(update->assets.at(0).browserDownloadUrl(), createDownloadUrl(evenNewerAssetName, evenNewerTag));
+    } else {
+        EXPECT_EQ(update->versionStr, newerVersion);
+        EXPECT_EQ(update->browserUrl, newerBrowserUrl);
+        EXPECT_EQ(update->assets.at(0).browserDownloadUrl(), createDownloadUrl(newerAssetName, newerTag));
+    }
+}
+
+TEST_P(AppUpdaterParseTest, ReleaseAndNotAutoInstallable)
+{
+    const std::string newerVersion = "9999.99.98";
+    const std::string evenNewerVersion = "9999.99.99";
+    const std::string newerTag = "v" + newerVersion;
+    const std::string evenNewerTag = "v" + evenNewerVersion;
+    const std::string updatedAt = "2026-04-03T08:29:48Z";
+    constexpr bool prerelease = false;
+    const std::string newerAssetName = "PopTracker-" + newerVersion + "-x86_64.AppImage";
+    const std::string evenNewerAssetName = "PopTracker-" + evenNewerVersion + "-x86_64.AppImage";
+    const std::string newerBrowserUrl = "1"; // is not validated
+    const std::string evenNewerBrowserUrl = "2";
+    const std::string s = json{
+        {
+            {"html_url", evenNewerBrowserUrl},
+            {"body", ""},
+            {"tag_name", evenNewerTag},
+            {"prerelease", prerelease},
+            {"updated_at", updatedAt},
+            {"assets", {
+                createAsset(evenNewerAssetName, evenNewerTag, updatedAt),
+                createAsset(evenNewerAssetName + ".minisig", evenNewerTag, updatedAt),
+            }}
+        },
+        {
+            {"html_url", newerBrowserUrl},
+            {"body", validPubKeyBody},
+            {"tag_name", newerTag},
+            {"prerelease", prerelease},
+            {"updated_at", updatedAt},
+            {"assets", {
+                createAsset(newerAssetName, newerTag, updatedAt),
+                createAsset(newerAssetName + ".minisig", newerTag, updatedAt),
+            }}
+        }
+    }.dump();
+
+    const auto update = updateFromResponse(s);
+    ASSERT_TRUE(update.has_value());
+    EXPECT_EQ(update->versionStr, newerVersion);
+    EXPECT_EQ(update->browserUrl, newerBrowserUrl);
+    EXPECT_EQ(update->assets.at(0).browserDownloadUrl(), createDownloadUrl(newerAssetName, newerTag));
+}
+
+
+INSTANTIATE_TEST_SUITE_P(IncludePreprelease, AppUpdaterParseTest, testing::Values(false, true));


### PR DESCRIPTION
also refactors the json -> update code and adds tests to validate the code