### PR TITLE
CI: update softprops/action-gh-release to v3.0.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
       with:
         subject-path: "*_full-source.tar.xz"
     - name: Create Release
-      uses: softprops/action-gh-release@975c1b265e11dd76618af1c374e7981f9a6ff44a
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
       with:
         draft: true
         prerelease: true
@@ -56,6 +56,7 @@ jobs:
           see [CHANGELOG.md](../v${{ env.RELEASE_VERSION }}/CHANGELOG.md)
           and [README.md](../v${{ env.RELEASE_VERSION }}/README.md)
         files: "*_full-source.tar.xz"
+        fail_on_unmatched_files: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -132,13 +133,14 @@ jobs:
           appimage-build/linux-x86_64/poptracker
           *.AppImage*
     - name: Create Release
-      uses: softprops/action-gh-release@975c1b265e11dd76618af1c374e7981f9a6ff44a
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
       with:
         draft: true
         prerelease: true
         name: PopTracker v${{ env.RELEASE_VERSION }}
         files: |
           *.AppImage
+        fail_on_unmatched_files: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -180,13 +182,14 @@ jobs:
           build/${{ env.UNAME }}/poptracker
           dist/*
     - name: Create Release
-      uses: softprops/action-gh-release@975c1b265e11dd76618af1c374e7981f9a6ff44a
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
       with:
         draft: true
         prerelease: true
         name: PopTracker v${{ env.RELEASE_VERSION }}
         files: |
           dist/*.tar.xz
+        fail_on_unmatched_files: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -215,13 +218,14 @@ jobs:
           build/darwin-x86_64/poptracker.app/Contents/MacOS/poptracker
           dist/*
     - name: Create Release
-      uses: softprops/action-gh-release@975c1b265e11dd76618af1c374e7981f9a6ff44a
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
       with:
         draft: true
         prerelease: true
         name: PopTracker v${{ env.RELEASE_VERSION }}
         files: |
           dist/*.zip
+        fail_on_unmatched_files: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -292,12 +296,13 @@ jobs:
           build/win64/poptracker.exe
           dist/*
     - name: Create Release
-      uses: softprops/action-gh-release@975c1b265e11dd76618af1c374e7981f9a6ff44a
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
       with:
         draft: true
         prerelease: true
         name: PopTracker v${{ env.RELEASE_VERSION }}
         files: |
           dist/*.zip
+        fail_on_unmatched_files: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
3.x will be required once Node 24 is EOL.
Also enable the new fail_on_unmatched.
Looked over changelog and changes and looks fine.

Supersedes #491, which would have updated from some in-between version to HEAD. We update to the latest tag instead.