### PR TITLE
CI: update msys2/setup-msys2 to v2.31.1

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -238,7 +238,7 @@ jobs:
       shell: bash
       run: |
         echo "UNAME=win64" >> $GITHUB_ENV
-    - uses: msys2/setup-msys2@4f806de0a5a7294ffabaff804b38a9b435a73bda  # v2.30.0
+    - uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c  # v2.31.1
       with:
         update: true
         install: >-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -233,7 +233,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: msys2/setup-msys2@4f806de0a5a7294ffabaff804b38a9b435a73bda  # v2.30.0
+    - uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c  # v2.31.1
       with:
         update: true
         install: >-

--- a/.github/workflows/scan-build.yaml
+++ b/.github/workflows/scan-build.yaml
@@ -61,7 +61,7 @@ jobs:
           sudo apt-get install coreutils build-essential libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libgtest-dev libgmock-dev
       - name: Install dependencies (msys2)
         if: ${{ startsWith(matrix.os, 'windows') }}
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c  # v2.31.1
         with:
           release: false
           update: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,7 +72,7 @@ jobs:
         brew install boost || true
     - name: Install dependencies (msys2, x86_64)
       if: ${{ startsWith(matrix.os, 'windows') && !endsWith(matrix.os, 'arm')}}
-      uses: msys2/setup-msys2@v2
+      uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c  # v2.31.1
       with:
         release: false
         update: false
@@ -90,7 +90,7 @@ jobs:
           p7zip
     - name: Install dependencies (msys2, arm)
       if: ${{ startsWith(matrix.os, 'windows') && endsWith(matrix.os, 'arm')}}
-      uses: msys2/setup-msys2@v2
+      uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c  # v2.31.1
       with:
         msystem: CLANGARM64
         update: true


### PR DESCRIPTION
Fixes Node 20 EOL warning and also pins version where we forgot it.