### PR TITLE
Feat: Print errors to stderr if file could not be read from pack, cleanup Image widget

### DIFF
--- a/src/ui/maptooltip.cpp
+++ b/src/ui/maptooltip.cpp
@@ -208,20 +208,19 @@ MapTooltip::MapTooltip(int x, int y, FONT font, FONT smallFont, int quality, Tra
 Item* MapTooltip::MakeLocationIcon(int x, int y, int width, int height, FONT font, int quality,
         Tracker* tracker, const std::string& locid, const LocationSection& sec, bool opened, bool compact)
 {
-    std::string fClosed, fOpened;
     std::string sClosed, sOpened;
 
-    fClosed = sec.getClosedImage();
-    tracker->getPack()->ReadFile(fClosed, sClosed);
-    if (sClosed.empty()) {
+    const std::string& fClosed = sec.getClosedImage();
+    if (!fClosed.empty() && !tracker->getPack()->ReadFile(fClosed, sClosed))
+        fprintf(stderr, "Error loading \"%s\"!\n", sanitize_print(fClosed).c_str());
+    if (sClosed.empty())
         readFile(asset("closed.png"), sClosed); // fallback/default icon
-    }
 
-    fOpened = sec.getOpenedImage();
-    tracker->getPack()->ReadFile(fOpened, sOpened);
-    if (sOpened.empty()) {
+    const std::string& fOpened = sec.getOpenedImage();
+    if (!fOpened.empty() && !tracker->getPack()->ReadFile(fOpened, sOpened))
+        fprintf(stderr, "Error loading \"%s\"!\n", sanitize_filename(fOpened).c_str());
+    if (sOpened.empty())
         readFile(asset("open.png"), sOpened); // fallback/default icon
-    }
 
     Item *w = new Item(x, y, width, height, font);
     w->setQuality(quality);

--- a/src/ui/trackerview.cpp
+++ b/src/ui/trackerview.cpp
@@ -57,8 +57,9 @@ static std::list<ImageFilter> imageModsToFilters(const Tracker* tracker, const s
             }
             if (name == "overlay") {
                 // read actual image data into arg instead of filename
-                std::string tmp = std::move(args[0]);
-                tracker->getPack()->ReadFile(tmp, args[0]);
+                const std::string tmp = std::move(args[0]);
+                if (!tracker->getPack()->ReadFile(tmp, args[0]))
+                    fprintf(stderr, "Error loading \"%s\" for overlay!\n", sanitize_filename(tmp).c_str());
                 for (size_t i=1; i<args.size(); ++i) {
                     if (args[i] == "@disable" || args[i] == "@disabled") {
                         if (disabledFilters.empty()) {
@@ -126,7 +127,8 @@ Item* TrackerView::makeItem(int x, int y, int width, int height, const ::BaseIte
 
     for (size_t n=0; n==0||n<stages; n++) {
         f = item->getImage(n);
-        _tracker->getPack()->ReadFile(f, s);
+        if (!_tracker->getPack()->ReadFile(f, s))
+            fprintf(stderr, "Error loading \"%s\"!\n", sanitize_filename(f).c_str());
         const auto& mods = item->getImageMods(n);
         auto filters = imageModsToFilters(_tracker, mods);
         if (origItem.getType() == ::BaseItem::Type::TOGGLE_BADGED) {
@@ -142,7 +144,8 @@ Item* TrackerView::makeItem(int x, int y, int width, int height, const ::BaseIte
             w->addStage(1, m, s.c_str(), s.length(), f, badgeFilters);
             if (n == 0 && m != 0) {
                 f = item->getDisabledImage(0);
-                _tracker->getPack()->ReadFile(f, s);
+                if (!_tracker->getPack()->ReadFile(f, s))
+                    fprintf(stderr, "Error loading \"%s\"!\n", sanitize_filename(f).c_str());
                 const auto& mods = item->getDisabledImageMods(0);
                 filters = imageModsToFilters(_tracker, mods);
                 w->addStage(0, 0, s.c_str(), s.length(), f, filters);
@@ -157,7 +160,8 @@ Item* TrackerView::makeItem(int x, int y, int width, int height, const ::BaseIte
             auto disF = item->getDisabledImage(n);
             if (f != disF) {
                 f = disF;
-                _tracker->getPack()->ReadFile(f, s);
+                if (!_tracker->getPack()->ReadFile(f, s))
+                    fprintf(stderr, "Error loading \"%s\"!\n", sanitize_filename(f).c_str());
             }
             auto disMods = item->getDisabledImageMods(n);
             filters = imageModsToFilters(_tracker, disMods);
@@ -202,7 +206,8 @@ Item* TrackerView::makeItem(int x, int y, int width, int height, const ::BaseIte
                 filters = imageModsToFilters(_tracker, commasplit<std::list>(img.substr(p + 1)));
             }
             std::string s;
-            _tracker->getPack()->ReadFile(f, s);
+            if (!_tracker->getPack()->ReadFile(f, s))
+                fprintf(stderr, "Error loading \"%s\"!\n", sanitize_filename(f).c_str());
             w->setImageOverride(s.c_str(), s.length(), f, filters);
         }
     }
@@ -563,7 +568,8 @@ void TrackerView::updateDisplay(const std::string& itemid)
                 filters = imageModsToFilters(_tracker, commasplit<std::list>(img.substr(p + 1)));
             }
             std::string s;
-            _tracker->getPack()->ReadFile(f, s);
+            if (!_tracker->getPack()->ReadFile(f, s))
+                fprintf(stderr, "Error loading \"%s\"!\n", sanitize_filename(f).c_str());
             w->setImageOverride(s.c_str(), s.length(), f, filters);
         } else {
             w->clearImageOverride();
@@ -580,7 +586,8 @@ void TrackerView::updateItem(Item* w, const BaseItem& item)
         // TODO: cache image instead always reloading it
         if (!w->isStage(w->getStage1(), w->getStage2(), f, filters)) {
             std::string s;
-            _tracker->getPack()->ReadFile(f, s);
+            if (!_tracker->getPack()->ReadFile(f, s))
+                fprintf(stderr, "Error loading \"%s\"!\n", sanitize_filename(f).c_str());
             w->addStage(w->getStage1(), w->getStage2(), s.c_str(), s.length(), f, filters);
             printf("Image updated!\n");
         }
@@ -887,7 +894,8 @@ bool TrackerView::addLayoutNode(Container* container, const LayoutNode& node, si
             const auto& map = _tracker->getMap(mapname);
             const auto& f = map.getImage();
             std::string s;
-            _tracker->getPack()->ReadFile(f, s);
+            if (!_tracker->getPack()->ReadFile(f, s))
+                fprintf(stderr, "Error loading \"%s\"!\n", sanitize_filename(f).c_str());
             MapWidget *w = new MapWidget(0,0,0,0, s.c_str(),s.length());
             w->setDropShaodw(node.getDropShadow(container->getDropShadow()));
             w->setHideClearedLocations(_hideClearedLocations);

--- a/src/uilib/image.cpp
+++ b/src/uilib/image.cpp
@@ -1,5 +1,5 @@
 #include "image.h"
-#include <stdio.h>
+#include <cstdio>
 #include <SDL2/SDL_image.h>
 #include "colorhelper.h"
 #include "imghelper.h"
@@ -8,42 +8,45 @@
 
 namespace Ui {
 
-Image::Image(int x, int y, int w, int h, const fs::path& path)
+Image::Image(const int x, const int y, const int w, const int h, const fs::path& path)
     : Widget(x,y,w,h)
 {
     setImage(path);
-    if (w<1 && h<1) {
+    if (w < 1 && h < 1) {
         _size.width = _autoSize.width;
         _size.height = _autoSize.height;
-    } else if (w<1 && _autoSize.height) {
-        _size.width = (_autoSize.width * h + _autoSize.height/2) / _autoSize.height;
-    } else if (h<1 && _autoSize.width) {
-        _size.height = (_autoSize.height * w + _autoSize.width/2) / _autoSize.width;
+    } else if (w < 1 && _autoSize.height) {
+        _size.width = (_autoSize.width * h + _autoSize.height / 2) / _autoSize.height;
+    } else if (h < 1 && _autoSize.width) {
+        _size.height = (_autoSize.height * w + _autoSize.width / 2) / _autoSize.width;
     }
 }
 
-Image::Image(int x, int y, int w, int h, const void* data, size_t len)
+Image::Image(const int x, const int y, const int w, const int h, const void* data, const size_t len)
     : Widget(x,y,w,h)
 {
     setImage(data, len);
-    if (w<1 && h<1) {
+    if (w < 1 && h < 1) {
         _size.width = _autoSize.width;
         _size.height = _autoSize.height;
-    } else if (w<1 && _autoSize.height) {
-        _size.width = (_autoSize.width * h + _autoSize.height/2) / _autoSize.height;
-    } else if (h<1 && _autoSize.width) {
-        _size.height = (_autoSize.height * w + _autoSize.width/2) / _autoSize.width;
+    } else if (w < 1 && _autoSize.height) {
+        _size.width = (_autoSize.width * h + _autoSize.height / 2) / _autoSize.height;
+    } else if (h < 1 && _autoSize.width) {
+        _size.height = (_autoSize.height * w + _autoSize.width / 2) / _autoSize.width;
     }
 }
 
 Image::~Image()
 {
-    if (_tex)   SDL_DestroyTexture(_tex);
-    if (_texBw) SDL_DestroyTexture(_texBw);
-    if (_surf)  SDL_FreeSurface(_surf);
-    _tex   = nullptr;
+    if (_tex)
+        SDL_DestroyTexture(_tex);
+    if (_texBw)
+        SDL_DestroyTexture(_texBw);
+    if (_surf)
+        SDL_FreeSurface(_surf);
+    _tex = nullptr;
     _texBw = nullptr;
-    _surf  = nullptr;
+    _surf = nullptr;
 }
 
 void Image::setImage(const fs::path& path)
@@ -53,12 +56,15 @@ void Image::setImage(const fs::path& path)
     if (path == _path && !path.empty())
         return; // unchanged
 
-    if (_tex)   SDL_DestroyTexture(_tex);
-    if (_texBw) SDL_DestroyTexture(_texBw);
-    if (_surf)  SDL_FreeSurface(_surf);
-    _tex   = nullptr;
+    if (_tex)
+        SDL_DestroyTexture(_tex);
+    if (_texBw)
+        SDL_DestroyTexture(_texBw);
+    if (_surf)
+        SDL_FreeSurface(_surf);
+    _tex = nullptr;
     _texBw = nullptr;
-    _surf  = nullptr;
+    _surf = nullptr;
     _autoSize = {0, 0};
 
     if (path.empty()) {
@@ -75,23 +81,26 @@ void Image::setImage(const fs::path& path)
     }
 }
 
-void Image::setImage(const void* data, size_t len)
+void Image::setImage(const void* data, const size_t len)
 {
     // NOTE: if the app hangs or crashes in IMG_Load_RW, you are probably mixing incompatible DLLs
     // FIXME: loading images takes a majority of the time to build the UI. Cache it!
-    if (_tex)   SDL_DestroyTexture(_tex);
-    if (_texBw) SDL_DestroyTexture(_texBw);
-    if (_surf)  SDL_FreeSurface(_surf);
-    _tex   = nullptr;
+    if (_tex)
+        SDL_DestroyTexture(_tex);
+    if (_texBw)
+        SDL_DestroyTexture(_texBw);
+    if (_surf)
+        SDL_FreeSurface(_surf);
+    _tex = nullptr;
     _texBw = nullptr;
-    _surf  = nullptr;
+    _surf = nullptr;
     _autoSize = {0, 0};
     _path.clear();
 
     if (!data || !len)
         return; // no data
 
-    _surf = IMG_Load_RW(SDL_RWFromMem((void*)data, (int)len), 1);
+    _surf = IMG_Load_RW(SDL_RWFromMem(const_cast<void *>(data), static_cast<int>(len)), 1);
     if (_surf) {
         _autoSize = {_surf->w, _surf->h};
     } else {
@@ -104,7 +113,7 @@ void Image::ensureTexture(Renderer renderer)
     if (!_tex && _surf) {
         if (_quality >= 0) {
             // set Texture filter/quality when creating the texture
-            char q[] = { (char)('0'+_quality), 0 };
+            char q[] = { static_cast<char>('0' + _quality), 0 };
             if (!SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, q)) {
                 printf("Image: could not set scale quality to %s!\n", q);
             }
@@ -121,54 +130,61 @@ void Image::ensureTexture(Renderer renderer)
     }
 }
 
-void Image::render(Renderer renderer, int offX, int offY)
+void Image::render(Renderer renderer, const int offX, const int offY)
 {
     if (_backgroundColor.a > 0) {
         const auto& c = _backgroundColor;
         SDL_SetRenderDrawColor(renderer, c.r, c.g, c.b, c.a);
-        SDL_Rect r = { offX+_pos.left, offY+_pos.top, _size.width, _size.height };
+        const SDL_Rect r = { offX+_pos.left, offY+_pos.top, _size.width, _size.height };
         SDL_RenderFillRect(renderer, &r);
     }
     ensureTexture(renderer);
-    auto tex = _enabled ? _tex : _texBw;
-    if (!tex) return;
+    const auto tex = _enabled ? _tex : _texBw;
+    if (!tex)
+        return;
     if (_fixedAspect) {
-        int finalw=0, finalh=0;
-        float ar = (float)_autoSize.width / (float)_autoSize.height;
-        finalw = (int)(_size.height * ar + 0.5);
-        finalh = _size.height;
-        if (finalw > _size.width) {
-            finalh = (int)(_size.width / ar + 0.5);
-            finalw = _size.width;
+        int finalW=0, finalH=0;
+        const float ar = static_cast<float>(_autoSize.width) / static_cast<float>(_autoSize.height);
+        finalW = static_cast<int>(_size.height * ar + 0.5);
+        finalH = _size.height;
+        if (finalW > _size.width) {
+            finalH = static_cast<int>(_size.width / ar + 0.5);
+            finalW = _size.width;
         }
-        SDL_Rect dest = {
-            offX+_pos.left + (_size.width-finalw+1)/2,
-            offY+_pos.top  + (_size.height-finalh+1)/2,
-            finalw,
-            finalh
+        const SDL_Rect dest = {
+            offX+_pos.left + (_size.width - finalW + 1) / 2,
+            offY+_pos.top + (_size.height - finalH + 1) / 2,
+            finalW,
+            finalH
         };
-        SDL_RenderCopy(renderer, tex, NULL, &dest);
+        SDL_RenderCopy(renderer, tex, nullptr, &dest);
     } else {
-        SDL_Rect dest = {offX+_pos.left, offY+_pos.top, _size.width, _size.height};
-        SDL_RenderCopy(renderer, tex, NULL, &dest);
+        const SDL_Rect dest = {offX+_pos.left, offY+_pos.top, _size.width, _size.height};
+        SDL_RenderCopy(renderer, tex, nullptr, &dest);
     }
 }
 
 void Image::setSize(Size size)
 {
     // TODO: make this default behaviour in Widget::setSize() ?
-    if (_size == size) return;
-    if (size.width<_minSize.width) size.width=_minSize.width;
-    if (size.height<_minSize.height) size.height=_minSize.height;
+    if (_size == size)
+        return;
+    if (size.width < _minSize.width)
+        size.width = _minSize.width;
+    if (size.height < _minSize.height)
+        size.height = _minSize.height;
     Widget::setSize(size);
 }
 
-void Image::setDarkenGreyscale(bool value)
+void Image::setDarkenGreyscale(const bool value)
 {
-    if (_darkenGreyscale == value) return;
+    if (_darkenGreyscale == value)
+        return;
     _darkenGreyscale = value;
-    if (_tex)   SDL_DestroyTexture(_tex);
-    if (_texBw) SDL_DestroyTexture(_texBw);
+    if (_tex)
+        SDL_DestroyTexture(_tex);
+    if (_texBw)
+        SDL_DestroyTexture(_texBw);
     _tex = nullptr;
     _texBw = nullptr;
 }

--- a/src/uilib/image.h
+++ b/src/uilib/image.h
@@ -1,9 +1,7 @@
-#ifndef _UILIB_IMAGE_H
-#define _UILIB_IMAGE_H
+#pragma once
 
 #include "widget.h"
 #include "../core/fs.h"
-#include <string>
 
 namespace Ui {
 
@@ -12,9 +10,9 @@ class Image : public Widget
 public:
     Image(int x, int y, int w, int h, const fs::path& path);
     Image(int x, int y, int w, int h, const void* data, size_t len);
-    ~Image();
-    virtual void render(Renderer renderer, int offX, int offY) override;
-    virtual void setSize(Size size) override;
+    ~Image() override;
+    void render(Renderer renderer, int offX, int offY) override;
+    void setSize(Size size) override;
     int getQuality() const { return _quality; }
     // NOTE: this has to be set before the image is rendered for the first time
     virtual void setQuality(int q) { _quality = q; }
@@ -29,11 +27,9 @@ protected:
     SDL_Texture *_tex = nullptr;
     SDL_Texture *_texBw = nullptr;
     fs::path _path;
-    bool _fixedAspect=true;
-    int _quality=-1;
+    bool _fixedAspect = true;
+    int _quality = -1;
     bool _darkenGreyscale = true; // makes greyscale version look "disabled"
 };
 
 } // namespace Ui
-
-#endif // _UILIB_IMAGE_H


### PR DESCRIPTION
Came up somewhere in Discord and has a "ticket" [there](https://discord.com/channels/937157230963339364/1171232344468901979/threads/1492461289333592174).

This PR also cleans up the Image widget, which turned out to be completely unrelated to the error reporting, but should be safe to just merge.