### PR TITLE
Update A Link Between Worlds AP Auto-tracker Pack

### DIFF
--- a/community-packs.json
+++ b/community-packs.json
@@ -91,10 +91,10 @@
     },
     "albw-ap-poptracker": {
         "name": "A Link Between Worlds Autotracker",
-        "author": "Legend",
+        "author": "Legend, maintained by guigui0246",
         "platform": "3DS",
-        "homepage": "https://github.com/Legendgreat/albw-ap-poptracker/",
-        "versions_url": "https://raw.githubusercontent.com/Legendgreat/albw-ap-poptracker/refs/heads/versions/versions.json",
+        "homepage": "https://github.com/guigui0246/albw-ap-poptracker/",
+        "versions_url": "https://raw.githubusercontent.com/guigui0246/albw-ap-poptracker/refs/heads/versions/versions.json",
         "icon_url": "https://raw.githubusercontent.com/Legendgreat/albw-ap-poptracker/main/images/items/maiamai.png",
         "description": "This is a PopTracker pack meant for tracking items and checks in The Legend of Zelda: A Link Between Worlds Randomizer runs, with AP integration for auto-tracking."
     },


### PR DESCRIPTION
As Legend stopped being active and responding to pings in discord and the pack needed an update as the randomizer got an update I forked the repo and continued it.
