### PR TITLE
CI: skip all caches when the output may be used by users

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -192,6 +192,7 @@ jobs:
       with:
         submodules: recursive
     - name: Cache/restore macosx-libs
+      if: ${{ github.event_name != 'workflow_dispatch' }}
       uses: actions/cache@v5.0.5
       with:
         key: libs-${{ runner.os }}-${{ runner.arch }}-${{ env.cache-name }}-${{ hashFiles('macosx/*.sh') }}
@@ -242,6 +243,7 @@ jobs:
     - uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c  # v2.31.1
       with:
         update: true
+        cache: ${{ github.event_name != 'workflow_dispatch' }}
         install: >-
           base-devel
           coreutils
@@ -262,6 +264,7 @@ jobs:
       with:
         submodules: recursive
     - name: Cache/restore win32-libs
+      if: ${{ github.event_name != 'workflow_dispatch' }}
       uses: actions/cache@v5.0.5
       with:
         key: libs-${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('win32/*.sh') }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -236,6 +236,7 @@ jobs:
     steps:
     - uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c  # v2.31.1
       with:
+        cache: false
         update: true
         install: >-
           base-devel


### PR DESCRIPTION
This is an extra safety measure to avoid malicious stuff making it onto users' machines, but also, attested builds really shouldn't use any unattested caches. I put my thoughts into words [on Discord](https://discord.com/channels/937157230963339364/937174275478138900/1504816047788916787).

This PR
* disables msys2 cache for release builds - I completely missed that it defaults to true
* disable caches if the `Build binaries` workflow was manually triggered (for testing), since we point people to `Build binaries` output for testing

Changes to `Build binaries` were verified here:
manually triggered: https://github.com/black-sliver/PopTracker/actions/runs/25973533775
vs.
automatically triggered: https://github.com/black-sliver/PopTracker/actions/runs/25973471988

Changes to Release workflow should be fine, but we'll see with the next release.