### PR TITLE
Fix some build errors when using mingw

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -385,10 +385,13 @@ update-cacert: assets/cacert.pem
 
 ifeq ($(CONF), DIST)
 cross: $(WIN32_ZIP) $(WIN64_ZIP)
+cross64: $(WIN64_ZIP)
 else
 cross: $(WIN32_EXE) $(WIN64_EXE)
+cross64: $(WIN64_EXE)
 endif
 cross-test: $(WIN32_TEST_EXE) $(WIN64_TEST_EXE)
+cross64-test: $(WIN64_TEST_EXE)
 	# TODO: run tests with wine
 
 # Project Targets

--- a/src/appupdater/appupdater.cpp
+++ b/src/appupdater/appupdater.cpp
@@ -355,7 +355,7 @@ void AppUpdater::installUpdate(const std::string& url, const fs::path& updater, 
                     fs::error_code ec;
                     const auto total = fs::file_size(path, ec);
                     if (!ec) {
-                        printf("Update: download complete: %zu\n", total);
+                        printf("Update: download complete: %ju\n", total);
                         onUpdateProgress.emit(this, url, static_cast<int>(total), static_cast<int>(total));
                     }
 #ifdef _WIN32


### PR DESCRIPTION
When building the tracker with mingw (in an archlinux WSL), I encountered problems with two source files.

In appupdater.cpp, the return type of `fs::file_size` is not necessarily `size_t`, so cast it before passing it to printf.

In miniz.c, it seems 32-bit mingw does not like a check that a buffer size does not exceed the 32 bit max. Make sure the constant is unsigned and of a large enough type to make the comparison not always be false.