### PR TITLE
Add Emerald to the Community List

### DIFF
--- a/community-packs.json
+++ b/community-packs.json
@@ -115,5 +115,14 @@
         "versions_url": "https://raw.githubusercontent.com/skipperki1/manual_powerwashsimulator_hallojasper_PopTracker/main/Manual%20Powerwash%20Simulator%20Poptracker/versions.json",
         "icon_url": "https://raw.githubusercontent.com/skipperki1/manual_powerwashsimulator_hallojasper_PopTracker/main/Manual%20Powerwash%20Simulator%20Poptracker/images/items/Trident.png",
         "description":  "Archipelago Map/Item Tracker and Manual Client for Powerwash Simulator."
+    },
+    "ap_emerald": {
+        "name": "Pokémon Emerald AP Tracker",
+        "author": "Seto10987 & palex00 & Vyneras",
+        "platform": "gba",
+        "homepage": "https://github.com/seto10987/Archipelago-Emerald-AP-Tracker",
+        "versions_url": "https://raw.githubusercontent.com/seto10987/archipelago-emerald-ap-tracker/versions/versions.json",
+        "icon_url": "https://raw.githubusercontent.com/palex00/rb_tracker/main/images/preview.png",
+        "description":  "Pokémon Emerald autotracker pack for PopTracker"
     }
 }

--- a/community-packs.json
+++ b/community-packs.json
@@ -122,7 +122,7 @@
         "platform": "gba",
         "homepage": "https://github.com/seto10987/Archipelago-Emerald-AP-Tracker",
         "versions_url": "https://raw.githubusercontent.com/seto10987/archipelago-emerald-ap-tracker/versions/versions.json",
-        "icon_url": "https://raw.githubusercontent.com/palex00/rb_tracker/main/images/preview.png",
+        "icon_url": "https://raw.githubusercontent.com/seto10987/archipelago-emerald-ap-tracker/main/images/preview.png",
         "description":  "Pokémon Emerald autotracker pack for PopTracker"
     }
 }


### PR DESCRIPTION
We just had a user use a pack from 3 years ago because it shows up on duckduckgo as the 2nd result if you search for "Pokemon Emerald Poptracker Pack"... so hopefully this fixes that.