### PR TITLE
Fix: invalid item image size crash

### DIFF
--- a/src/ui/item.cpp
+++ b/src/ui/item.cpp
@@ -142,7 +142,10 @@ void Item::addStage(const int stage1, const int stage2, std::unique_ptr<ImageFut
     freeStage(stage1, stage2);
     if (!future)
         return;
-    updateSize(future->getSize());
+    const Size size = future->getSize();
+    if (size.width < 1 || size.height < 1)
+        return; // bad image
+    updateSize(size);
     if (static_cast<int>(_futures.size()) <= stage1)
         _futures.resize(stage1 + 1);
     if (static_cast<int>(_futures[stage1].size()) <= stage2)

--- a/src/ui/item.cpp
+++ b/src/ui/item.cpp
@@ -80,9 +80,9 @@ void Item::updateSize(const Size size)
     if (_size.width < 1 && _size.height < 1) {
         _size.width = _autoSize.width;
         _size.height = _autoSize.height;
-    } else if (_size.width < 1) {
+    } else if (_size.width < 1 && _autoSize.height > 0) {
         _size.width = (_autoSize.width * _size.height + _autoSize.height / 2) / _autoSize.height;
-    } else if (_size.height < 1) {
+    } else if (_size.height < 1 && _autoSize.width > 0) {
         _size.height = (_autoSize.height * _size.width + _autoSize.width / 2) / _autoSize.width;
     }
 }


### PR DESCRIPTION
* ignore invalid images in Item::addStage (this was different between ImageFuture and old code)
* don't try to calculate real size from aspect ratio when the raw image size is invalid (this is where the crash happened)