### PR TITLE
Add macOS Apple Silicon native build support

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -271,6 +271,13 @@ jobs:
         # ditto preserves the signature's extended attributes (a plain zip strips them)
         ditto -c -k --keepParent --sequesterRsrc --zlibCompressionLevel 9 poptracker.app "dist/poptracker_${VS}_macos_universal.zip"
         ls -l dist
+    - name: Attest Build and AppBundle
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26  # v4.1.0
+      with:
+        subject-path: |
+          poptracker.app/Contents/MacOS/poptracker
+          dist/*
     - name: Store universal ZIP
       uses: actions/upload-artifact@v7.0.1
       with:

--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -173,14 +173,20 @@ jobs:
         if-no-files-found: error
 
   build-macos:
-    runs-on: macos-15-intel
-    
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-15-intel  # x86_64
+          - macos-15        # arm64 (Apple Silicon)
+
     steps:
     - name: Set env
       shell: bash
       run: |
         OS=darwin
-        ARCH=x86_64
+        ARCH=`uname -m`
         echo "OS=$OS" >> $GITHUB_ENV
         echo "ARCH=$ARCH" >> $GITHUB_ENV
         echo "UNAME=$OS-$ARCH" >> $GITHUB_ENV

--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -231,7 +231,47 @@ jobs:
         subject-path: |
           build/${{ env.UNAME }}/poptracker.app/Contents/MacOS/poptracker
           dist/*
-    - name: Store ZIP/DMG
+    - name: Package app bundle for universal merge
+      run: |
+        # tar (rather than uploading the .app directly) preserves the bundle's
+        # symlinks and permissions across the artifact round-trip.
+        tar -czf "poptracker-${{ env.ARCH }}.tar.gz" -C "build/${{ env.UNAME }}" poptracker.app
+    - name: Upload per-arch app bundle
+      uses: actions/upload-artifact@v7.0.1
+      with:
+        name: macos-app-${{ env.ARCH }}
+        path: poptracker-${{ env.ARCH }}.tar.gz
+        if-no-files-found: error
+
+  build-macos-universal:
+    needs: build-macos
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v6.0.3
+    - name: Download per-arch app bundles
+      uses: actions/download-artifact@v8.0.1
+      with:
+        pattern: macos-app-*
+        path: dl
+        merge-multiple: true
+    - name: Merge into a universal2 bundle
+      run: |
+        mkdir -p arm64 x86_64
+        tar -xzf dl/poptracker-arm64.tar.gz -C arm64
+        tar -xzf dl/poptracker-x86_64.tar.gz -C x86_64
+        bash macosx/make_universal.sh arm64/poptracker.app x86_64/poptracker.app poptracker.app
+        # lipo invalidates code signatures; re-sign ad-hoc and verify
+        codesign --force --deep --sign - poptracker.app
+        codesign --verify --deep --strict poptracker.app
+        lipo -info poptracker.app/Contents/MacOS/poptracker
+    - name: Package universal ZIP
+      run: |
+        VS=`./poptracker.app/Contents/MacOS/poptracker --version | tr '.' '-'`
+        mkdir -p dist
+        # ditto preserves the signature's extended attributes (a plain zip strips them)
+        ditto -c -k --keepParent --sequesterRsrc --zlibCompressionLevel 9 poptracker.app "dist/poptracker_${VS}_macos_universal.zip"
+        ls -l dist
+    - name: Store universal ZIP
       uses: actions/upload-artifact@v7.0.1
       with:
         path: dist/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -225,11 +225,53 @@ jobs:
       run: make test CONF=RELEASE VERSION=${{ env.RELEASE_VERSION }}
     - name: Build DIST # this builds the app bundle, zips it and maybe .dmg in the future
       run: make CONF=DIST VERSION=${{ env.RELEASE_VERSION }}
+    - name: Package app bundle for universal merge
+      run: |
+        # tar preserves the bundle's symlinks and permissions across the artifact round-trip.
+        tar -czf "poptracker-${{ env.ARCH }}.tar.gz" -C "build/${{ env.UNAME }}" poptracker.app
+    - name: Upload per-arch app bundle
+      uses: actions/upload-artifact@v7.0.1
+      with:
+        name: macos-app-${{ env.ARCH }}
+        path: poptracker-${{ env.ARCH }}.tar.gz
+        if-no-files-found: error
+
+  release-macos-universal:
+    needs: release-macos
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v6.0.3
+    - name: Set env
+      shell: bash
+      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+    - name: Download per-arch app bundles
+      uses: actions/download-artifact@v8.0.1
+      with:
+        pattern: macos-app-*
+        path: dl
+        merge-multiple: true
+    - name: Merge into a universal2 bundle
+      run: |
+        mkdir -p arm64 x86_64
+        tar -xzf dl/poptracker-arm64.tar.gz -C arm64
+        tar -xzf dl/poptracker-x86_64.tar.gz -C x86_64
+        bash macosx/make_universal.sh arm64/poptracker.app x86_64/poptracker.app poptracker.app
+        # lipo invalidates code signatures; re-sign ad-hoc and verify
+        codesign --force --deep --sign - poptracker.app
+        codesign --verify --deep --strict poptracker.app
+        lipo -info poptracker.app/Contents/MacOS/poptracker
+    - name: Package universal ZIP
+      run: |
+        VS=`./poptracker.app/Contents/MacOS/poptracker --version | tr '.' '-'`
+        mkdir -p dist
+        # ditto preserves the signature's extended attributes (a plain zip strips them)
+        ditto -c -k --keepParent --sequesterRsrc --zlibCompressionLevel 9 poptracker.app "dist/poptracker_${VS}_macos_universal.zip"
+        ls -l dist
     - name: Attest Build and AppBundle
       uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26  # v4.1.0
       with:
         subject-path: |
-          build/${{ env.UNAME }}/poptracker.app/Contents/MacOS/poptracker
+          poptracker.app/Contents/MacOS/poptracker
           dist/*
     - name: Create Release
       uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -194,7 +194,13 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release-macos:
-    runs-on: macos-15-intel
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-15-intel  # x86_64
+          - macos-15        # arm64 (Apple Silicon)
 
     steps:
     - name: Install dependencies
@@ -205,7 +211,14 @@ jobs:
       with:
         submodules: recursive
     - name: Set env
-      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+      shell: bash
+      run: |
+        echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+        OS=darwin
+        ARCH=`uname -m`
+        echo "OS=$OS" >> $GITHUB_ENV
+        echo "ARCH=$ARCH" >> $GITHUB_ENV
+        echo "UNAME=$OS-$ARCH" >> $GITHUB_ENV
     - name: Build RELEASE
       run: make native CONF=RELEASE VERSION=${{ env.RELEASE_VERSION }} -j4
     - name: Run tests
@@ -216,7 +229,7 @@ jobs:
       uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26  # v4.1.0
       with:
         subject-path: |
-          build/darwin-x86_64/poptracker.app/Contents/MacOS/poptracker
+          build/${{ env.UNAME }}/poptracker.app/Contents/MacOS/poptracker
           dist/*
     - name: Create Release
       uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ win32-lib-src
 /fuzz-*.log
 /oom-*
 /crash-*
+macosx/libs/

--- a/Makefile
+++ b/Makefile
@@ -514,7 +514,7 @@ $(OSX_ZIP): $(OSX_APP) | $(DIST_DIR)
 	# quarantined copy report as "damaged and can't be opened". ditto is Apple's
 	# archiver, is always present on macOS/CI runners, and preserves the
 	# signing metadata so the .app stays validly signed after extraction.
-	ditto -c -k --keepParent --sequesterRsrc "$<" "$@"
+	ditto -c -k --keepParent --sequesterRsrc --zlibCompressionLevel 9 "$<" "$@"
 
 $(NIX_XZ): $(NIX_EXE) | $(DIST_DIR)
 	$(eval TMP_DIR = $(DIST_DIR)/.tmp-nix)

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ HTML = $(WASM_BUILD_DIR)/$(EXE_NAME).html
 ifeq ($(CONF), DIST)
 ifdef IS_OSX
   OSX_APP := $(NIX_BUILD_DIR)/poptracker.app
-  OSX_ZIP := $(DIST_DIR)/poptracker_$(VS)_macos.zip
+  OSX_ZIP := $(DIST_DIR)/poptracker_$(VS)_macos_$(ARCH).zip
 else ifdef IS_LINUX
   DISTRO = $(shell lsb_release -si | tr -s ' ' '-' | tr A-Z a-z )
   DISTRO_VERSION = $(shell lsb_release -sr | tr -s '.' '-' | tr A-z a-z )

--- a/Makefile
+++ b/Makefile
@@ -508,11 +508,13 @@ test_osx_app: $(OSX_APP)
 
 $(OSX_ZIP): $(OSX_APP) | $(DIST_DIR)
 	rm -f $@
-	(cd $(dir $<) && \
-	    if [ -x "`which 7z`" ]; then 7z a -mx=9 ../../dist/$(notdir $@) $(notdir $<) -x!.DS_Store; \
-	    else zip -9 -r ../../dist/$(notdir $@) $(notdir $<) -x "*.DS_Store" ; fi && \
-	    if [ -x "`which advzip`" ]; then advzip --recompress -4 ../$(notdir $@) ; fi \
-	)
+	# Use ditto, not zip/7z: the app's resources live under Contents/MacOS, so
+	# codesign signs them as nested code via extended attributes. Plain zip
+	# (Info-ZIP) drops xattrs, which breaks the signature and makes a
+	# quarantined copy report as "damaged and can't be opened". ditto is Apple's
+	# archiver, is always present on macOS/CI runners, and preserves the
+	# signing metadata so the .app stays validly signed after extraction.
+	ditto -c -k --keepParent --sequesterRsrc "$<" "$@"
 
 $(NIX_XZ): $(NIX_EXE) | $(DIST_DIR)
 	$(eval TMP_DIR = $(DIST_DIR)/.tmp-nix)

--- a/macosx/bundle_macosx_app.sh
+++ b/macosx/bundle_macosx_app.sh
@@ -221,3 +221,21 @@ install_name_tool -change $OLD_LIB_SDL2_IMAGE @executable_path/../Frameworks/$LI
 install_name_tool -change $OLD_LIB_SDL2_TTF @executable_path/../Frameworks/$LIB_SDL2_TTF $DST_EXE
 install_name_tool -change $OLD_LIB_OPENSSL @executable_path/../Frameworks/$LIB_OPENSSL $DST_EXE
 install_name_tool -change $OLD_LIB_CRYPTO @executable_path/../Frameworks/$LIB_CRYPTO $DST_EXE
+
+# Re-sign the bundle (ad-hoc).
+#
+# Every install_name_tool edit above invalidates the code signature that the
+# linker applied to each Mach-O. On Apple Silicon a valid signature is
+# mandatory to execute, and a bundle whose seal no longer matches its contents
+# is reported by Gatekeeper as "damaged and can't be opened" once the copy has
+# been quarantined (i.e. downloaded/AirDropped to another Mac). Re-sign each
+# nested dylib, then the executable, then seal the whole bundle.
+#
+# This is an ad-hoc signature (identity "-"), not a Developer ID / notarized
+# one, so first launch of a quarantined copy still needs a one-time approval
+# (right-click > Open, or `xattr -dr com.apple.quarantine <app>`); but the app
+# is no longer reported as damaged and runs normally thereafter.
+echo "Ad-hoc code signing the app bundle"
+codesign --force --sign - "$APP_BUNDLE_FRAMEWORKS_DIR"/*.dylib
+codesign --force --sign - "$DST_EXE"
+codesign --force --deep --sign - "$APP_BUNDLE_DIR"

--- a/macosx/make_universal.sh
+++ b/macosx/make_universal.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Combine two single-architecture macOS .app bundles into one universal2 bundle.
+#
+# Usage: make_universal.sh <app_a> <app_b> <out_app>
+#
+# The two inputs must be the same build for different architectures (identical
+# layout). Every Mach-O file is lipo-merged; everything else (data files,
+# symlinks, Info.plist, ...) is taken verbatim from the first bundle, which is
+# cloned with ditto to preserve permissions, symlinks and metadata.
+#
+# The result is unsigned (lipo invalidates signatures) -- re-sign the output
+# bundle afterwards (e.g. `codesign --force --deep --sign - <out_app>`).
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+    echo "usage: $0 <app_a> <app_b> <out_app>" >&2
+    exit 2
+fi
+
+APP_A="$1"
+APP_B="$2"
+OUT="$3"
+
+rm -rf "$OUT"
+ditto "$APP_A" "$OUT"   # faithful clone: perms, symlinks, xattrs
+
+# lipo every Mach-O file that exists in both bundles
+find "$APP_A" -type f -print0 | while IFS= read -r -d '' f; do
+    rel="${f#"$APP_A"/}"
+    if file -b "$f" | grep -q 'Mach-O' && [ -f "$APP_B/$rel" ]; then
+        lipo -create "$APP_A/$rel" "$APP_B/$rel" -output "$OUT/$rel"
+    fi
+done
+
+echo "Universal bundle written to: $OUT"
+lipo -info "$OUT/Contents/MacOS/$(basename "${OUT%.app}")" 2>/dev/null || true


### PR DESCRIPTION
Hi! I noticed that PopTracker didn't have a native Apple Silicon build, which will be required starting from the next macOS release (Rosetta will be removed). Considering this, I wanted to add proper support to avoid any future issues. 

I was able to build PopTracker, run it on my M1 Pro MacBook Pro, using a Majora's Mask pack, and connect to an AP server. As far as I could see, everything seemed to work perfectly fine. Build atrifacts available here: https://github.com/MarcDufresne/PopTracker/actions/runs/27890842995

I had to update the build process a bit, like proper signature and packaging, and some small tweaks to naming since macOS now has 2 architectures to build.

Cheers!