### PR TITLE
Add gray/grayscale as alias for grey/greyscale

### DIFF
--- a/doc/PACKS.md
+++ b/doc/PACKS.md
@@ -289,12 +289,14 @@ a table representing an enum with the following constants: \
   + img_mods filter to be applied on the img
     - `@disabled`: as defined in `settings.json`'s "disabled_image_filter"; defaults to `grey`
     - `grey`: 0% saturation + 67% brightness
+    - `gray`: same as `grey`; since 0.35.4
     - `disable`: same as `grey`
     - `overlay|path/to/img.png|overlay_filters...`: draw a second image over it; overlay_filters are applied to overlay (since 0.25.6)
     - `brightness|x`: set image brightness by multiplying all colors with `x` (decimal); since 0.32.2
     - `dim`: same as `brightness|0.5`; since 0.32.2
     - `saturation|x|colorspace`: set saturation to `x`, if colorspace is `bt601` emulate brightness levels, otherwise average r, g, b; since 0.32.2
     - `greyscale`: same as `saturation|0`; since 0.32.2
+    - `grayscale`: same as `greyscale`; since 0.35.4
     - NOTE: order matters, applied left to right
   + inherit_codes: true will make stage3 provide codes for item, stage1, 2 and 3 (default true)
 

--- a/src/uilib/imagefilter.cpp
+++ b/src/uilib/imagefilter.cpp
@@ -38,7 +38,7 @@ SDL_Surface* ImageFilter::apply(SDL_Surface *surf) const
         }
     }
 
-    if (name == "grey" || name == "disable") {
+    if (name == "grey" || name == "gray" || name == "disable") {
         return makeGreyscale(surf, true);
     }
     if (name == "saturation") {
@@ -64,7 +64,7 @@ SDL_Surface* ImageFilter::apply(SDL_Surface *surf) const
         }
         return setBrightness(surf, value);
     }
-    if (name == "greyscale") {
+    if (name == "greyscale" || name == "grayscale") {
         // same as saturation|0
         // arg1: colorspace; bt601 = "color-corrected"; all other: AVG(r, g, b)
         bool mode = false;

--- a/test/uilib/test_imagefilter.cpp
+++ b/test/uilib/test_imagefilter.cpp
@@ -24,7 +24,8 @@ class ImageFilterSuite : public testing::TestWithParam<std::string_view>
 {
 };
 
-static std::string getSampleOverlayData() {
+static std::string getSampleOverlayData()
+{
     static std::string res;
     if (res.empty()) {
         [[maybe_unused]]
@@ -34,37 +35,52 @@ static std::string getSampleOverlayData() {
     return res;
 }
 
-static std::string getPaletteData(SDL_Surface* surf) {
+static std::string getPaletteData(const SDL_Surface* surf)
+{
     if (surf->format->palette) {
-        return {(const char*)surf->format->palette->colors, sizeof(SDL_Color) * surf->format->palette->ncolors};
+        return {reinterpret_cast<const char *>(surf->format->palette->colors), sizeof(SDL_Color) * surf->format->palette->ncolors};
+    }
+    return {};
+}
+
+static std::string getPixelData(const SDL_Surface* surf)
+{
+    if (surf->pixels) {
+        assert(surf->h > 0 && surf->pitch > 0);
+        return {static_cast<const char *>(surf->pixels), static_cast<std::string::size_type>(surf->h * surf->pitch)};
     }
     return {};
 }
 
 TEST_P(ImageFilterSuite, NullInNullOut) {
     SDL_Surface *surf = nullptr;
-    ImageFilter filter(std::string{GetParam()}, getSampleOverlayData());
+    const ImageFilter filter(std::string{GetParam()}, getSampleOverlayData());
     EXPECT_EQ(surf, filter.apply(surf));
 }
 
 TEST_P(ImageFilterSuite, SomethingInOtherOut) {
-    auto surf = IMG_Load(asset("closed.png").u8string().c_str());
+    SDL_Surface* surf = IMG_Load(asset("closed.png").u8string().c_str());
     ASSERT_TRUE(surf);
-    std::string originalData((const char*)surf->pixels, surf->h * surf->pitch);
-    std::string originalPalette = getPaletteData(surf);
-    ImageFilter filter(std::string{GetParam()}, getSampleOverlayData());
-    SDL_Surface *surf2 = filter.apply(surf);
+    const std::string originalData = getPixelData(surf);
+    const std::string originalPalette = getPaletteData(surf);
+    const ImageFilter filter(std::string{GetParam()}, getSampleOverlayData());
+    SDL_Surface* surf2 = filter.apply(surf);
     ASSERT_TRUE(surf2);
-    std::string modifiedData((const char*)surf2->pixels, surf2->h * surf2->pitch);
+    const std::string modifiedData = getPixelData(surf2);
     if (surf2->format->palette) {
         // filter may just change the palette for images with color palette
-        std::string modifiedPalette = getPaletteData(surf2);
+        const std::string modifiedPalette = getPaletteData(surf2);
         EXPECT_TRUE(originalData != modifiedData || originalPalette != modifiedPalette);
     } else {
         // filter has to modify data if the image has no color palette
         EXPECT_NE(originalData, modifiedData);
     }
     SDL_FreeSurface(surf2);
+    if (surf != surf2) {
+        // we expected filter to modify the surface in place
+        SDL_FreeSurface(surf);
+        FAIL() << "Unexpected copy of surf";
+    }
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -84,8 +100,8 @@ TEST(ImageFilterTest, GreyscaleIsSaturation0) {
     const ImageFilter filter2("saturation", "0");
     SDL_Surface *surf2 = filter2.apply(surf0);
     ASSERT_TRUE(surf2);
-    const std::string data1(static_cast<const char *>(surf1->pixels), surf1->h * surf1->pitch);
-    const std::string data2(static_cast<const char *>(surf2->pixels), surf2->h * surf2->pitch);
+    const std::string data1 = getPixelData(surf1);
+    const std::string data2 = getPixelData(surf2);
     EXPECT_EQ(data1, data2);
     if (surf1->format->palette) {
         ASSERT_TRUE(surf2->format->palette);
@@ -108,8 +124,8 @@ TEST(ImageFilterTest, DimIsHalfBrightness) {
     const ImageFilter filter2("brightness", "0.5");
     SDL_Surface *surf2 = filter2.apply(surf0);
     ASSERT_TRUE(surf2);
-    const std::string data1(static_cast<const char *>(surf1->pixels), surf1->h * surf1->pitch);
-    const std::string data2(static_cast<const char *>(surf2->pixels), surf2->h * surf2->pitch);
+    const std::string data1 = getPixelData(surf1);
+    const std::string data2 = getPixelData(surf2);
     EXPECT_EQ(data1, data2);
     if (surf1->format->palette) {
         ASSERT_TRUE(surf2->format->palette);
@@ -133,8 +149,8 @@ TEST(ImageFilterTest, BT601IsNotDefault) {
     const ImageFilter filter2("saturation", "0");
     SDL_Surface *surf2 = filter2.apply(surf0);
     ASSERT_TRUE(surf2);
-    const std::string data1(static_cast<const char *>(surf1->pixels), surf1->h * surf1->pitch);
-    const std::string data2(static_cast<const char *>(surf2->pixels), surf2->h * surf2->pitch);
+    const std::string data1 = getPixelData(surf1);
+    const std::string data2 = getPixelData(surf2);
     if (data1 == data2) {
         ASSERT_TRUE(surf1->format->palette);
         ASSERT_TRUE(surf2->format->palette);
@@ -145,35 +161,45 @@ TEST(ImageFilterTest, BT601IsNotDefault) {
 }
 
 TEST(ImageFilterTest, UnknownFilterUnmodified) {
-    auto surf = IMG_Load(asset("closed.png").u8string().c_str());
+    SDL_Surface* surf = IMG_Load(asset("closed.png").u8string().c_str());
     ASSERT_TRUE(surf);
-    std::string originalData((const char*)surf->pixels, surf->h * surf->pitch);
-    std::string originalPalette = getPaletteData(surf);
-    ImageFilter filter("unknown", getSampleOverlayData());
-    SDL_Surface *surf2 = filter.apply(surf);
+    const std::string originalData = getPixelData(surf);
+    const std::string originalPalette = getPaletteData(surf);
+    const ImageFilter filter("unknown", getSampleOverlayData());
+    SDL_Surface* surf2 = filter.apply(surf);
     ASSERT_TRUE(surf2);
     EXPECT_EQ(surf, surf2);
-    std::string modifiedData((const char*)surf2->pixels, surf2->h * surf2->pitch);
-    std::string modifiedPalette = getPaletteData(surf2);
+    const std::string modifiedData = getPixelData(surf2);
+    const std::string modifiedPalette = getPaletteData(surf2);
     EXPECT_EQ(originalData, modifiedData);
     EXPECT_EQ(originalPalette, modifiedPalette);
     SDL_FreeSurface(surf2);
+    if (surf != surf2) {
+        // we expected filter to modify the surface in place
+        SDL_FreeSurface(surf);
+        FAIL() << "Unexpected copy of surf";
+    }
 }
 
 TEST(ImageFilterTest, MissingOverlayUnmodied) {
-    auto surf = IMG_Load(asset("closed.png").u8string().c_str());
+    SDL_Surface* surf = IMG_Load(asset("closed.png").u8string().c_str());
     ASSERT_TRUE(surf);
-    std::string originalData((const char*)surf->pixels, surf->h * surf->pitch);
-    std::string originalPalette = getPaletteData(surf);
-    ImageFilter filter("overlay", "");
-    SDL_Surface *surf2 = filter.apply(surf);
+    const std::string originalData = getPixelData(surf);
+    const std::string originalPalette = getPaletteData(surf);
+    const ImageFilter filter("overlay", "");
+    SDL_Surface* surf2 = filter.apply(surf);
     ASSERT_TRUE(surf2);
     EXPECT_EQ(surf, surf2);
-    std::string modifiedData((const char*)surf2->pixels, surf2->h * surf2->pitch);
-    std::string modifiedPalette = getPaletteData(surf2);
+    const std::string modifiedData = getPixelData(surf2);
+    const std::string modifiedPalette = getPaletteData(surf2);
     EXPECT_EQ(originalData, modifiedData);
     EXPECT_EQ(originalPalette, modifiedPalette);
     SDL_FreeSurface(surf2);
+    if (surf != surf2) {
+        // we expected filter to modify the surface in place
+        SDL_FreeSurface(surf);
+        FAIL() << "Unexpected copy of surf";
+    }
 }
 
 TEST(ImageFilterTest, FilteredOverlay) {
@@ -184,27 +210,33 @@ TEST(ImageFilterTest, FilteredOverlay) {
     std::string data2;
     std::string palette2;
     {
-        auto surf = IMG_Load(asset("closed.png").u8string().c_str());
+        SDL_Surface* surf = IMG_Load(asset("closed.png").u8string().c_str());
         ASSERT_TRUE(surf);
         ImageFilter filter("overlay", getSampleOverlayData());
-        SDL_Surface *surf2 = filter.apply(surf);
+        SDL_Surface* surf2 = filter.apply(surf);
         ASSERT_TRUE(surf2);
-        data1 = std::string((const char*)surf2->pixels, surf2->h * surf2->pitch);
+        data1 = getPixelData(surf2);
         palette1 = getPaletteData(surf2);
         SDL_FreeSurface(surf2);
+        if (surf != surf2) // we expected filter to modify the surface in place
+            SDL_FreeSurface(surf);
+        EXPECT_EQ(surf, surf2) << "Unexpected copy of surf";
     }
     {
-        auto surf = IMG_Load(asset("closed.png").u8string().c_str());
+        SDL_Surface* surf = IMG_Load(asset("closed.png").u8string().c_str());
         ASSERT_TRUE(surf);
-        data0 = std::string((const char*)surf->pixels, surf->h * surf->pitch);
+        data0 = getPixelData(surf);
         palette0 = getPaletteData(surf);
         std::vector<std::string> args = {getSampleOverlayData(), "grey"};
         ImageFilter filter("overlay", args);
-        SDL_Surface *surf2 = filter.apply(surf);
+        SDL_Surface* surf2 = filter.apply(surf);
         ASSERT_TRUE(surf2);
-        data2 = std::string((const char*)surf2->pixels, surf2->h * surf2->pitch);
+        data2 = getPixelData(surf2);
         palette2 = getPaletteData(surf2);
         SDL_FreeSurface(surf2);
+        if (surf != surf2) // we expected filter to modify the surface in place
+            SDL_FreeSurface(surf);
+        EXPECT_EQ(surf, surf2) << "Unexpected copy of surf";
     }
     ASSERT_TRUE(data0 != data2 || palette0 != palette2);
     ASSERT_TRUE(data1 != data2 || palette1 != palette2);
@@ -224,9 +256,9 @@ TEST(ImageFilterTest, CompareArgVector) {
     std::vector<std::string> args1 = {"arg1", "arg2"};
     std::vector<std::string> args2 = {"arg1", "arg2"};
     std::vector<std::string> args3 = {"arg1", "arg2", "arg3"};
-    ImageFilter filter("test", args1);
-    ImageFilter same("test", args2);
-    ImageFilter other("test", args3);
+    const ImageFilter filter("test", args1);
+    const ImageFilter same("test", args2);
+    const ImageFilter other("test", args3);
     EXPECT_EQ(filter, same);
     EXPECT_FALSE(filter == other);
 }

--- a/test/uilib/test_imagefilter.cpp
+++ b/test/uilib/test_imagefilter.cpp
@@ -11,9 +11,11 @@ using namespace Ui;
 
 #define ALL_KNOWN_FILTERS \
 "grey", \
+"gray", \
 "disable", \
 "saturation", \
 "greyscale", \
+"grayscale", \
 "brightness", \
 "dim", \
 "overlay"

--- a/test/uilib/test_imagefilter.cpp
+++ b/test/uilib/test_imagefilter.cpp
@@ -83,6 +83,29 @@ TEST_P(ImageFilterSuite, SomethingInOtherOut) {
     }
 }
 
+TEST_P(ImageFilterSuite, MakesCopyIfRequired) {
+    SDL_Surface* surf = IMG_Load(asset("closed.png").u8string().c_str());
+    ASSERT_TRUE(surf);
+#ifdef SDL_DONTFREE
+    surf->flags |= SDL_DONTFREE;
+#else
+    surf->refcount = 2;
+#endif
+    const std::string originalData = getPixelData(surf);
+    const std::string originalPalette = getPaletteData(surf);
+    const ImageFilter filter(std::string{GetParam()}, getSampleOverlayData());
+    SDL_Surface* surf2 = filter.apply(surf);
+#ifdef SDL_DONTFREE
+    surf->flags &= ~SDL_DONTFREE;
+#else
+    surf->refcount = 1;
+#endif
+    SDL_FreeSurface(surf);
+    ASSERT_NE(surf, surf2) << "Did not make a copy";
+    ASSERT_TRUE(surf2);
+    SDL_FreeSurface(surf2);
+}
+
 INSTANTIATE_TEST_SUITE_P(
     KnownFilters,
     ImageFilterSuite,


### PR DESCRIPTION
In the future we'll swap those (gray being canonical, grey being an alias) since everything else is American english.

Also adds new filter names to tests and tests that the filter copies or reuses the surface depending on if it's shared or not.