### PR TITLE
CI: Disable ASAN on macos, add timeout

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -117,7 +117,8 @@ jobs:
         # since we don't build gtest with ASAN, we hit this issue on macos-latest
         echo "ASAN_OPTIONS=detect_container_overflow=0" >> $GITHUB_ENV
     - name: Enable ASAN and UBSAN
-      if: ${{ !startsWith(matrix.os, 'windows') }}
+      # if: ${{ !startsWith(matrix.os, 'windows') }}
+      if: ${{ startsWith(matrix.os, 'ubuntu') }}
       run: |
         # we use mingw on windows, which does not support ASAN
         echo "extra_make_args=WITH_ASAN=true WITH_UBSAN=true ${{ matrix.extra_make_args }}" >> $GITHUB_ENV

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -130,6 +130,7 @@ jobs:
     - name: Build DEBUG
       run: make native CONF=DEBUG ${{ env.extra_make_args }} -j4
     - name: Run tests
+      timeout-minutes: 7
       run: make test CONF=DEBUG ${{ env.extra_make_args }} -j4
 
   nix-shell-build:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -121,7 +121,12 @@ jobs:
       if: ${{ startsWith(matrix.os, 'ubuntu') }}
       run: |
         # we use mingw on windows, which does not support ASAN
+        # macos currently hangs when trying to run tests with ASAN + UBSAN on
         echo "extra_make_args=WITH_ASAN=true WITH_UBSAN=true ${{ matrix.extra_make_args }}" >> $GITHUB_ENV
+    - name: Enable UBSAN
+      if: ${{ startsWith(matrix.os, 'macos') }}
+      run: |
+        echo "extra_make_args=WITH_UBSAN=true ${{ matrix.extra_make_args }}" >> $GITHUB_ENV
     - name: Build DEBUG
       run: make native CONF=DEBUG ${{ env.extra_make_args }} -j4
     - name: Run tests


### PR DESCRIPTION
Since the last runner images update, trying to run unit tests with ASAN enabled hangs on macos.

This disables ASAN (only enables UBSAN) and adds a timeout for the hanging step.