### PR TITLE
Fix false negative return for various Add functions

### DIFF
--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -453,7 +453,7 @@ bool Tracker::AddLocations(const std::string& file) {
     }
 
     onLayoutChanged.emit(this, ""); // TODO: differentiate between structure and content
-    return false;
+    return true;
 }
 bool Tracker::AddMaps(const std::string& file) {
     printf("Loading maps from \"%s\"...\n", file.c_str());
@@ -479,7 +479,7 @@ bool Tracker::AddMaps(const std::string& file) {
     }
     
     onLayoutChanged.emit(this, ""); // TODO: differentiate between structure and content
-    return false;
+    return true;
 }
 bool Tracker::AddLayouts(const std::string& file) {
     printf("Loading layouts from \"%s\"...\n", file.c_str());
@@ -515,7 +515,7 @@ bool Tracker::AddLayouts(const std::string& file) {
     
     // TODO: fire for each named layout
     onLayoutChanged.emit(this, ""); // TODO: differentiate between structure and content
-    return false;
+    return true;
 }
 
 bool Tracker::AddClasses(const std::string& file) {
@@ -544,7 +544,7 @@ bool Tracker::AddClasses(const std::string& file) {
         _classes.emplace(key, value);
     }
 
-    return false;
+    return true;
 }
 
 int Tracker::ProviderCountForCode(const std::string& code)


### PR DESCRIPTION
This fixes PopTracker returning false for AddLocations, AddMaps, AddLayouts, and AddClasses even though they're successful

Example of AddLocations showing oasis.jsonc claim to fail loading, but the locations are still visible:
<img width="2657" height="1060" alt="image" src="https://github.com/user-attachments/assets/3ec0a839-c62d-4731-af75-31ebd65fa9b2" />
