### PR TITLE
Add --ap-host, --ap-slot and --ap-password CLI args for auto-connecting to Archipelago

### DIFF
--- a/doc/commandline.txt
+++ b/doc/commandline.txt
@@ -22,3 +22,8 @@ Usage: poptracker [<ARGS...>] [<ACTION ARGS...>] [<ACTION>|<path/to/pack>]
     --pack-variant <variant>: try to load this variant
     --pack-version <version>: try to load this version
 
+  AP Connection:
+    --ap-host <host:port>: Archipelago server address
+    --ap-slot <name>: slot name to connect as
+    --ap-password <password>: password for the server
+

--- a/src/core/autotracker.h
+++ b/src/core/autotracker.h
@@ -216,6 +216,15 @@ public:
         return BACKEND_NONE_NAME;
     }
 
+    int getIndex(const std::string& name)
+    {
+        if (name == BACKEND_AP_NAME && _ap) return _backendIndex[_ap];
+        if (name == BACKEND_UAT_NAME && _uat) return _backendIndex[_uat];
+        if (name == BACKEND_SNES_NAME && _snes) return _backendIndex[_snes];
+        if (_provider && name == _provider->getName()) return _backendIndex[_provider];
+        return -1;
+    }
+
     std::string getSubName(int index)
     {
         if (_snes && _backendIndex[_snes] == index)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -108,17 +108,29 @@ int main(int argc, char** argv)
             argv++;
             argc--;
         } else if (strcasecmp("--ap-password", argv[1]) == 0) {
-            if (argc <= 2) { badArg = true; break; }
+            if (argc <= 2) {
+                badArg = true;
+                break;
+            }
             apPassword = argv[2];
-            argv++; argc--;
+            argv++;
+            argc--;
         } else if (strcasecmp("--ap-slot", argv[1]) == 0) {
-            if (argc <= 2) { badArg = true; break; }
+            if (argc <= 2) {
+                badArg = true;
+                break;
+            }
             apSlot = argv[2];
-            argv++; argc--;
+            argv++;
+            argc--;
         } else if (strcasecmp("--ap-host", argv[1]) == 0) {
-            if (argc <= 2) { badArg = true; break; }
+            if (argc <= 2) {
+                badArg = true;
+                break;
+            }
             apHost = argv[2];
-            argv++; argc--;
+            argv++;
+            argc--;
         } else if (strcasecmp("--pack-variant", argv[1]) == 0) {
             if (argc <= 2) {
                 badArg = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,9 @@ int main(int argc, char** argv)
     const char* loadPack = nullptr;
     const char* packPath = nullptr;
     const char* packVersion = nullptr;
+    const char* apHost = nullptr;
+    const char* apSlot = nullptr;
+    const char* apPassword = nullptr;
     const char* packVariant = nullptr;
     bool updateAttempt = false;
     bool updateSuccess = false;
@@ -104,6 +107,18 @@ int main(int argc, char** argv)
             packVersion = argv[2];
             argv++;
             argc--;
+        } else if (strcasecmp("--ap-password", argv[1]) == 0) {
+            if (argc <= 2) { badArg = true; break; }
+            apPassword = argv[2];
+            argv++; argc--;
+        } else if (strcasecmp("--ap-slot", argv[1]) == 0) {
+            if (argc <= 2) { badArg = true; break; }
+            apSlot = argv[2];
+            argv++; argc--;
+        } else if (strcasecmp("--ap-host", argv[1]) == 0) {
+            if (argc <= 2) { badArg = true; break; }
+            apHost = argv[2];
+            argv++; argc--;
         } else if (strcasecmp("--pack-variant", argv[1]) == 0) {
             if (argc <= 2) {
                 badArg = true;
@@ -168,6 +183,11 @@ int main(int argc, char** argv)
                "  Action args:\n"
                "    --pack-variant <variant>: try to load this variant\n"
                "    --pack-version <version>: try to load this version\n"
+               "\n"
+               "  AP Connection:\n"
+               "    --ap-host <host:port>: Archipelago server address\n"
+               "    --ap-slot <name>: slot name to connect as\n"
+               "    --ap-password <password>: password for the server\n"
                "\n", appName);
         return badArg ? 1 : 0;
     }
@@ -193,6 +213,13 @@ int main(int argc, char** argv)
     if (updateAttempt) {
         args["update"] = {
             { "success", updateSuccess },
+        };
+    }
+    if (apHost) {
+        args["ap"] = {
+            {"host", apHost},
+            {"slot", apSlot ? apSlot : "Player"},
+            {"password", apPassword ? apPassword : ""}
         };
     }
 

--- a/src/poptracker.cpp
+++ b/src/poptracker.cpp
@@ -955,17 +955,14 @@ bool PopTracker::frame()
     if (_scriptHost) {
         _scriptHost->onFrame();
         if (_apConnectPending && !_apHostFromArgs.empty() && !_apSlotFromArgs.empty()) {
+            _apConnectPending = false;
             auto at = _scriptHost->getAutoTracker();
             if (at) {
-                for (int i = 0; i < 32; i++) {
-                    if (at->getName(i) == "AP") {
-                        if (at->enable(i, _apHostFromArgs, _apSlotFromArgs, _atPassword)) {
-                            _apConnectPending = false;
-                            _autoTrackerAllDisabled = false;
-                            _autoTrackerDisabled["AP"] = false;
-                        }
-                        break;
-                    }
+                int i = at->getIndex("AP");
+                if (i >= 0) {
+                    at->enable(i, _apHostFromArgs, _apSlotFromArgs, _atPassword);
+                    _autoTrackerAllDisabled = false;
+                    _autoTrackerDisabled["AP"] = false;
                 }
             }
         }

--- a/src/poptracker.cpp
+++ b/src/poptracker.cpp
@@ -294,6 +294,16 @@ PopTracker::PopTracker([[maybe_unused]] int argc, [[maybe_unused]] char** argv, 
     if (_config["at_slot"].is_string())
         _atSlot = _config["at_slot"];
 
+    if (_args.contains("ap")) {
+        const auto& ap = _args["ap"];
+        _config["at_uri"] = to_string(ap["host"], "");
+        _config["at_slot"] = to_string(ap["slot"], "Player");
+        _atPassword = to_string(ap["password"], "");
+        _apHostFromArgs = to_string(ap["host"], "");
+        _apSlotFromArgs = to_string(ap["slot"], "Player");
+        _apConnectPending = true;
+    }
+
     if (_config["usb2snes"].is_null())
         _config["usb2snes"] = "";
 
@@ -942,8 +952,24 @@ bool PopTracker::frame()
         // when all tasks are done, poll() will stop(). Reset for next request.
         if (_asio->stopped()) _asio->restart();
     }
-    if (_scriptHost)
+    if (_scriptHost) {
         _scriptHost->onFrame();
+        if (_apConnectPending && !_apHostFromArgs.empty() && !_apSlotFromArgs.empty()) {
+            auto at = _scriptHost->getAutoTracker();
+            if (at) {
+                for (int i = 0; i < 32; i++) {
+                    if (at->getName(i) == "AP") {
+                        if (at->enable(i, _apHostFromArgs, _apSlotFromArgs, _atPassword)) {
+                            _apConnectPending = false;
+                            _autoTrackerAllDisabled = false;
+                            _autoTrackerDisabled["AP"] = false;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    }
 
     auto now = std::chrono::steady_clock::now();
 

--- a/src/poptracker.h
+++ b/src/poptracker.h
@@ -66,6 +66,8 @@ private:
     std::chrono::steady_clock::time_point _autosaveTimer;
 
     std::string _atUri, _atSlot, _atPassword;
+    bool _apConnectPending = false;
+    std::string _apHostFromArgs, _apSlotFromArgs;
 
     bool loadTracker(const fs::path& pack, const std::string& variant, bool loadAutosave=true);
     bool scheduleLoadTracker(const fs::path& pack, const std::string& variant, bool loadAutosave=true);


### PR DESCRIPTION
### Disclaimer;  All code changes was done with AI as I do not know cpp. However, I do understand almost all of the code, so for anyone reviewing, I want you to keep an extra eye for anything that looks strange.

### What it does:
Three new command-line arguments allow PopTracker to automatically
connect to an Archipelago server on startup:

  --ap-host <host:port>   Server address (e.g. archipelago.gg:38281)
  --ap-slot <name>        Slot/player name to connect as
  --ap-password <pw>      Server password (optional)

The connection is attempted once the tracker pack is loaded and the AP backend is available, using a frame-loop poll to handle async pack loading timing. Values from CLI args will override values from autosave state and config files, but not change them. 

This is all tested and currently running locally using version 0.35.3. 
