### PR TITLE
Fix wrong warning for invalid base_item

### DIFF
--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -330,8 +330,16 @@ bool Tracker::AddItems(const std::string& file) {
         }
         // connect item onChange to badged (if badged was defined first)
         if (item.getType() == BaseItem::Type::TOGGLE_BADGED) {
-            fprintf(stderr, "WARNING: ignored %s as base_item of badged\n",
-                BaseItem::Type2Str(item.getType()).c_str());
+            if (!_missingBaseItemConnection.empty()) {
+                for (const auto& code: item.getCodes(0)) {
+                    if (_missingBaseItemConnection.find(JsonItem::toLower(code))
+                            != _missingBaseItemConnection.end()) {
+                        fprintf(stderr, "WARNING: ignored %s as base_item of badged\n",
+                            BaseItem::Type2Str(item.getType()).c_str());
+                        break;
+                    }
+                }
+            }
         } else {
             for (const auto& code: item.getCodes(0)) {
                 auto it = _missingBaseItemConnection.find(JsonItem::toLower(code));


### PR DESCRIPTION
The `break` is because if there are multiple issues, fixing one will surface the next anyway.

Tested on Discord.

Note that some badged -> badged links are accepted; this warning should show for base_item recursion.