### PR TITLE
Cache which Lua items can provide a code

### DIFF
--- a/src/core/luaitem.cpp
+++ b/src/core/luaitem.cpp
@@ -102,7 +102,6 @@ bool LuaItem::Lua_NewIndex(lua_State *L, const char *key) {
     } else if (strcmp(key,"ItemState")==0) {
         if (_itemState.valid()) luaL_unref(L, LUA_REGISTRYINDEX, _itemState.ref);
         _itemState.ref = luaL_ref(L, LUA_REGISTRYINDEX); // pop copy and store
-        onCodesChanged.emit(this);
         return true;
     } else if (strcmp(key,"Icon")==0) {
         // NOTE: this is a fake ImageReference, not just a path, so this can include ":mods" to preapply mods
@@ -142,7 +141,6 @@ bool LuaItem::Lua_NewIndex(lua_State *L, const char *key) {
         return true;
     } else if (strcmp(key,"CanProvideCodeFunc")==0) {
         _canProvideCodeFunc.ref = luaL_ref(L, LUA_REGISTRYINDEX); // pop copy and store
-        onCodesChanged.emit(this);
         return true;
     } else if (strcmp(key,"ProvidesCodeFunc")==0) {
         _providesCodeFunc.ref = luaL_ref(L, LUA_REGISTRYINDEX); // pop copy and store

--- a/src/core/luaitem.cpp
+++ b/src/core/luaitem.cpp
@@ -102,6 +102,7 @@ bool LuaItem::Lua_NewIndex(lua_State *L, const char *key) {
     } else if (strcmp(key,"ItemState")==0) {
         if (_itemState.valid()) luaL_unref(L, LUA_REGISTRYINDEX, _itemState.ref);
         _itemState.ref = luaL_ref(L, LUA_REGISTRYINDEX); // pop copy and store
+        onCanProvideCodeChanged.emit(this);
         return true;
     } else if (strcmp(key,"Icon")==0) {
         // NOTE: this is a fake ImageReference, not just a path, so this can include ":mods" to preapply mods
@@ -141,6 +142,7 @@ bool LuaItem::Lua_NewIndex(lua_State *L, const char *key) {
         return true;
     } else if (strcmp(key,"CanProvideCodeFunc")==0) {
         _canProvideCodeFunc.ref = luaL_ref(L, LUA_REGISTRYINDEX); // pop copy and store
+        onCanProvideCodeChanged.emit(this);
         return true;
     } else if (strcmp(key,"ProvidesCodeFunc")==0) {
         _providesCodeFunc.ref = luaL_ref(L, LUA_REGISTRYINDEX); // pop copy and store

--- a/src/core/luaitem.cpp
+++ b/src/core/luaitem.cpp
@@ -102,6 +102,7 @@ bool LuaItem::Lua_NewIndex(lua_State *L, const char *key) {
     } else if (strcmp(key,"ItemState")==0) {
         if (_itemState.valid()) luaL_unref(L, LUA_REGISTRYINDEX, _itemState.ref);
         _itemState.ref = luaL_ref(L, LUA_REGISTRYINDEX); // pop copy and store
+        onCodesChanged.emit(this);
         return true;
     } else if (strcmp(key,"Icon")==0) {
         // NOTE: this is a fake ImageReference, not just a path, so this can include ":mods" to preapply mods

--- a/src/core/luaitem.cpp
+++ b/src/core/luaitem.cpp
@@ -141,6 +141,7 @@ bool LuaItem::Lua_NewIndex(lua_State *L, const char *key) {
         return true;
     } else if (strcmp(key,"CanProvideCodeFunc")==0) {
         _canProvideCodeFunc.ref = luaL_ref(L, LUA_REGISTRYINDEX); // pop copy and store
+        onCodesChanged.emit(this);
         return true;
     } else if (strcmp(key,"ProvidesCodeFunc")==0) {
         _providesCodeFunc.ref = luaL_ref(L, LUA_REGISTRYINDEX); // pop copy and store
@@ -177,7 +178,6 @@ bool LuaItem::Lua_NewIndex(lua_State *L, const char *key) {
 
 bool LuaItem::canProvideCode(const std::string& code) const
 {
-    // TODO: cache result for performance reasons
     if (!_canProvideCodeFunc.valid())
         return false;
     lua_rawgeti(_L, LUA_REGISTRYINDEX, _canProvideCodeFunc.ref);

--- a/src/core/luaitem.h
+++ b/src/core/luaitem.h
@@ -20,8 +20,6 @@ public:
     void Set(const char* key, const LuaVariant& value);
     LuaVariant Get(const char* key);
 
-    Signal<> onCodesChanged; ///< fired when whatever answers canProvideCode is (re)assigned
-
     bool canProvideCode(const std::string& code) const override;
     int providesCode(const std::string& code) const override;
     bool changeState(Action action) override;

--- a/src/core/luaitem.h
+++ b/src/core/luaitem.h
@@ -20,6 +20,8 @@ public:
     void Set(const char* key, const LuaVariant& value);
     LuaVariant Get(const char* key);
 
+    Signal<> onCodesChanged; ///< fired when CanProvideCodeFunc is (re)assigned
+
     bool canProvideCode(const std::string& code) const override;
     int providesCode(const std::string& code) const override;
     bool changeState(Action action) override;

--- a/src/core/luaitem.h
+++ b/src/core/luaitem.h
@@ -20,7 +20,7 @@ public:
     void Set(const char* key, const LuaVariant& value);
     LuaVariant Get(const char* key);
 
-    Signal<> onCodesChanged; ///< fired when CanProvideCodeFunc is (re)assigned
+    Signal<> onCodesChanged; ///< fired when whatever answers canProvideCode is (re)assigned
 
     bool canProvideCode(const std::string& code) const override;
     int providesCode(const std::string& code) const override;

--- a/src/core/luaitem.h
+++ b/src/core/luaitem.h
@@ -20,6 +20,10 @@ public:
     void Set(const char* key, const LuaVariant& value);
     LuaVariant Get(const char* key);
 
+    /// fired when CanProvideCodeFunc or ItemState is assigned.
+    /// NOTE: mutating ItemState in place does not fire this.
+    Signal<> onCanProvideCodeChanged;
+
     bool canProvideCode(const std::string& code) const override;
     int providesCode(const std::string& code) const override;
     bool changeState(Action action) override;

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -185,6 +185,7 @@ bool Tracker::AddItems(const std::string& file) {
     
     _providerCountCache.clear();
     _objectCache.clear();
+    _luaProviderCache.clear();
     _accessibilityStale = true;
     _visibilityStale = true;
     for (auto& v : j) {
@@ -372,6 +373,7 @@ bool Tracker::AddLocations(const std::string& file) {
     
     _providerCountCache.clear();
     _objectCache.clear();
+    _luaProviderCache.clear();
     _sectionRefs.clear();
     _accessibilityStale = true;
     _visibilityStale = true;
@@ -547,6 +549,23 @@ bool Tracker::AddClasses(const std::string& file) {
     return true;
 }
 
+const std::vector<const LuaItem*>& Tracker::luaProvidersForCode(const std::string& code) const
+{
+    // LuaItem::canProvideCode is a lua_pcall per item, so scanning all lua items for every code
+    // is expensive for packs with many of them. canProvideCode is defined as "can this item EVER
+    // provide this code", so the result is cached until the set of items or locations changes.
+    auto it = _luaProviderCache.find(code);
+    if (it != _luaProviderCache.end())
+        return it->second;
+
+    std::vector<const LuaItem*> providers;
+    for (const auto& item: _luaItems) {
+        if (item.canProvideCode(code))
+            providers.push_back(&item);
+    }
+    return _luaProviderCache.insert_or_assign(code, std::move(providers)).first->second;
+}
+
 int Tracker::ProviderCountForCode(const std::string& code)
 {
     // cache this, because inefficient use can make the Lua script hang
@@ -581,13 +600,13 @@ int Tracker::ProviderCountForCode(const std::string& code)
     }
 #endif
 
-    for (const auto& item : _luaItems)
+    // copied because providesCode calls into Lua, which may invalidate the cache
+    const auto providers = luaProvidersForCode(code);
+    for (const auto* item : providers)
     {
-        if (item.canProvideCode(code)) {
-            _luaCodesStack.emplace_back(code);
-            res += item.providesCode(code);
-            _luaCodesStack.pop_back();
-        }
+        _luaCodesStack.emplace_back(code);
+        res += item->providesCode(code);
+        _luaCodesStack.pop_back();
     }
 
     if (!_indirectlyConnectedLuaCodes.count(code))
@@ -640,11 +659,9 @@ Tracker::Object Tracker::FindObjectForCode(const char* code)
         }
 #endif
 
-        for (auto& item : _luaItems) {
-            if (item.canProvideCode(code)) {
-                return _objectCache.emplace(code, &item).first->second;
-            }
-        }
+        const auto& providers = luaProvidersForCode(code);
+        if (!providers.empty())
+            return _objectCache.emplace(code, const_cast<LuaItem*>(providers.front())).first->second;
     }
     printf("Did not find object for code \"%s\".\n", sanitize_print(code).c_str());
     return nullptr;
@@ -752,10 +769,9 @@ const BaseItem& Tracker::getItemByCode(const std::string& code) const
     }
 #endif
 
-    for (const auto& item: _luaItems) {
-        if (item.canProvideCode(code))
-            return item;
-    }
+    const auto& providers = luaProvidersForCode(code);
+    if (!providers.empty())
+        return *providers.front();
 
     return blankItem;
 }
@@ -1131,6 +1147,7 @@ LuaItem * Tracker::CreateLuaItem()
 {
     _luaItems.emplace_back();
     _objectCache.clear();
+    _luaProviderCache.clear();
     LuaItem& i = _luaItems.back();
     i.setID(++_lastItemID);
     {

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -1163,6 +1163,7 @@ LuaItem * Tracker::CreateLuaItem()
     i.onCodesChanged += {this, [this](void*) {
         _luaProviderCache.clear();
         _providerCountCache.clear();
+        _objectCache.clear();
     }};
     i.onChange += {this, [this](void* sender) {
         const auto* i = static_cast<LuaItem*>(sender);

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -201,6 +201,7 @@ bool Tracker::AddItems(const std::string& file) {
             const auto* i = static_cast<JsonItem*>(sender);
             if (!_updatingCache || !_itemChangesDuringCacheUpdate.count(i->getID())) {
                 _providerCountCache.clear();
+                _luaProviderCache.clear();
                 _accessibilityStale = true;
                 _visibilityStale = true;
                 if (_updatingCache)
@@ -395,6 +396,7 @@ bool Tracker::AddLocations(const std::string& file) {
                     sec.onChange += {this,[this,&sec](void*) {
                         // TODO: only touch caches and stale if sec's AvailableChestCount is involved in logic
                         _providerCountCache.clear();
+                        _luaProviderCache.clear();
                         _accessibilityStale = true;
                         _visibilityStale = true;
                         if (_bulkUpdate)
@@ -444,6 +446,7 @@ bool Tracker::AddLocations(const std::string& file) {
             sec.onChange += {this,[this,&sec](void*) {
                 // TODO: only touch caches and stale if sec's AvailableChestCount is involved in logic
                 _providerCountCache.clear();
+                _luaProviderCache.clear();
                 _accessibilityStale = true;
                 _visibilityStale = true;
                 if (_bulkUpdate)
@@ -552,8 +555,8 @@ bool Tracker::AddClasses(const std::string& file) {
 const std::vector<const LuaItem*>& Tracker::luaProvidersForCode(const std::string& code) const
 {
     // LuaItem::canProvideCode is a lua_pcall per item, so scanning all lua items for every code
-    // is expensive for packs with many of them. canProvideCode is defined as "can this item EVER
-    // provide this code", so the result is cached until the set of items or locations changes.
+    // is expensive for packs with many of them. Cached with the same lifetime as
+    // _providerCountCache, which does not cache codes in _indirectlyConnectedLuaCodes.
     auto it = _luaProviderCache.find(code);
     if (it != _luaProviderCache.end())
         return it->second;
@@ -1160,15 +1163,11 @@ LuaItem * Tracker::CreateLuaItem()
             i.setSource(ar.source, ar.currentline);
         }
     }
-    i.onCodesChanged += {this, [this](void*) {
-        _luaProviderCache.clear();
-        _providerCountCache.clear();
-        _objectCache.clear();
-    }};
     i.onChange += {this, [this](void* sender) {
         const auto* i = static_cast<LuaItem*>(sender);
         if (!_updatingCache || !_itemChangesDuringCacheUpdate.count(i->getID())) {
             _providerCountCache.clear();
+            _luaProviderCache.clear();
             _accessibilityStale = true;
             _visibilityStale = true;
             if (_updatingCache)
@@ -1347,6 +1346,7 @@ json Tracker::saveState() const
 bool Tracker::loadState(nlohmann::json& state)
 {
     _providerCountCache.clear();
+    _luaProviderCache.clear();
     _bulkItemUpdates.clear();
     _bulkItemDisplayUpdates.clear();
     _accessibilityStale = true;

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -201,7 +201,6 @@ bool Tracker::AddItems(const std::string& file) {
             const auto* i = static_cast<JsonItem*>(sender);
             if (!_updatingCache || !_itemChangesDuringCacheUpdate.count(i->getID())) {
                 _providerCountCache.clear();
-                _luaProviderCache.clear();
                 _accessibilityStale = true;
                 _visibilityStale = true;
                 if (_updatingCache)
@@ -396,7 +395,6 @@ bool Tracker::AddLocations(const std::string& file) {
                     sec.onChange += {this,[this,&sec](void*) {
                         // TODO: only touch caches and stale if sec's AvailableChestCount is involved in logic
                         _providerCountCache.clear();
-                        _luaProviderCache.clear();
                         _accessibilityStale = true;
                         _visibilityStale = true;
                         if (_bulkUpdate)
@@ -446,7 +444,6 @@ bool Tracker::AddLocations(const std::string& file) {
             sec.onChange += {this,[this,&sec](void*) {
                 // TODO: only touch caches and stale if sec's AvailableChestCount is involved in logic
                 _providerCountCache.clear();
-                _luaProviderCache.clear();
                 _accessibilityStale = true;
                 _visibilityStale = true;
                 if (_bulkUpdate)
@@ -555,8 +552,8 @@ bool Tracker::AddClasses(const std::string& file) {
 const std::vector<const LuaItem*>& Tracker::luaProvidersForCode(const std::string& code) const
 {
     // LuaItem::canProvideCode is a lua_pcall per item, so scanning all lua items for every code
-    // is expensive for packs with many of them. Cached with the same lifetime as
-    // _providerCountCache, which does not cache codes in _indirectlyConnectedLuaCodes.
+    // is expensive for packs with many of them. canProvideCode is defined as "can this item EVER
+    // provide this code", so the result is cached until the set of items or locations changes.
     auto it = _luaProviderCache.find(code);
     if (it != _luaProviderCache.end())
         return it->second;
@@ -1163,11 +1160,15 @@ LuaItem * Tracker::CreateLuaItem()
             i.setSource(ar.source, ar.currentline);
         }
     }
+    i.onCanProvideCodeChanged += {this, [this](void*) {
+        _luaProviderCache.clear();
+        _providerCountCache.clear();
+        _objectCache.clear();
+    }};
     i.onChange += {this, [this](void* sender) {
         const auto* i = static_cast<LuaItem*>(sender);
         if (!_updatingCache || !_itemChangesDuringCacheUpdate.count(i->getID())) {
             _providerCountCache.clear();
-            _luaProviderCache.clear();
             _accessibilityStale = true;
             _visibilityStale = true;
             if (_updatingCache)
@@ -1346,7 +1347,6 @@ json Tracker::saveState() const
 bool Tracker::loadState(nlohmann::json& state)
 {
     _providerCountCache.clear();
-    _luaProviderCache.clear();
     _bulkItemUpdates.clear();
     _bulkItemDisplayUpdates.clear();
     _accessibilityStale = true;

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -1160,6 +1160,10 @@ LuaItem * Tracker::CreateLuaItem()
             i.setSource(ar.source, ar.currentline);
         }
     }
+    i.onCodesChanged += {this, [this](void*) {
+        _luaProviderCache.clear();
+        _providerCountCache.clear();
+    }};
     i.onChange += {this, [this](void* sender) {
         const auto* i = static_cast<LuaItem*>(sender);
         if (!_updatingCache || !_itemChangesDuringCacheUpdate.count(i->getID())) {

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -133,6 +133,7 @@ protected:
     std::map<std::string, bool> _visibilityCache;
     std::map<std::string, int> _providerCountCache;
     std::map<const std::string, Object, std::less<>> _objectCache;
+    mutable std::map<std::string, std::vector<const LuaItem*>, std::less<>> _luaProviderCache; ///< code -> lua items that can provide it
     std::list<std::string> _bulkItemUpdates;
     std::list<std::string> _bulkItemDisplayUpdates;
     std::vector<std::string> _bulkSectionUpdates;
@@ -160,6 +161,8 @@ protected:
         const std::list< std::list<std::string> >& rules,
         bool visibilityRules,
         bool glitchedScoutableAsGlitched);
+
+    const std::vector<const LuaItem*>& luaProvidersForCode(const std::string& code) const;
 
     void rebuildSectionRefs();
     void cacheAccessibility();

--- a/test/core/test_luaitem.cpp
+++ b/test/core/test_luaitem.cpp
@@ -100,6 +100,27 @@ TEST(LuaItemProvidesTest, CanProvideCodeIsCached) {
             clicks = clicks + 1
             self.Icon = "icon" .. clicks  -- trigger onChange
         end
+        function makeTrampolineItem()
+            local function invokeCanProvideCode(item, code)
+                return item.ItemState:canProvideCode(code)
+            end
+            local function invokeProvidesCode(item, code)
+                return item.ItemState:providesCode(code)
+            end
+            trampoline = ScriptHost:CreateLuaItem()
+            trampoline.ItemState = {
+                canProvideCode = function(self, code) return code == "First" end,
+                providesCode = function(self, code) return (code == "First") and 1 or 0 end,
+            }
+            trampoline.CanProvideCodeFunc = invokeCanProvideCode
+            trampoline.ProvidesCodeFunc = invokeProvidesCode
+        end
+        function swapTrampolineState()
+            trampoline.ItemState = {
+                canProvideCode = function(self, code) return code == "Second" end,
+                providesCode = function(self, code) return (code == "Second") and 1 or 0 end,
+            }
+        end
         function makeLateItem()
             lateItem = ScriptHost:CreateLuaItem()
             lateItem.Name = "late"
@@ -161,6 +182,16 @@ TEST(LuaItemProvidesTest, CanProvideCodeIsCached) {
     lua_getglobal(L, "giveLateItemCodes");
     ASSERT_EQ(lua_pcall(L, 0, 0, 0), LUA_OK) << lua_tostring(L, -1);
     EXPECT_EQ(tracker.ProviderCountForCode("Late"), 1);
+
+    // what answers canProvideCode may live in ItemState rather than in CanProvideCodeFunc
+    lua_getglobal(L, "makeTrampolineItem");
+    ASSERT_EQ(lua_pcall(L, 0, 0, 0), LUA_OK) << lua_tostring(L, -1);
+    EXPECT_EQ(tracker.ProviderCountForCode("First"), 1);
+    EXPECT_EQ(tracker.ProviderCountForCode("Second"), 0);
+    lua_getglobal(L, "swapTrampolineState");
+    ASSERT_EQ(lua_pcall(L, 0, 0, 0), LUA_OK) << lua_tostring(L, -1);
+    EXPECT_EQ(tracker.ProviderCountForCode("First"), 0);
+    EXPECT_EQ(tracker.ProviderCountForCode("Second"), 1);
 
     lua_close(L);
 }

--- a/test/core/test_luaitem.cpp
+++ b/test/core/test_luaitem.cpp
@@ -100,6 +100,39 @@ TEST(LuaItemProvidesTest, CanProvideCodeIsCached) {
             clicks = clicks + 1
             self.Icon = "icon" .. clicks  -- trigger onChange
         end
+        function makeTrampolineItem()
+            local function invokeCanProvideCode(item, code)
+                return item.ItemState:canProvideCode(code)
+            end
+            local function invokeProvidesCode(item, code)
+                return item.ItemState:providesCode(code)
+            end
+            trampoline = ScriptHost:CreateLuaItem()
+            trampoline.ItemState = {
+                canProvideCode = function(self, code) return code == "First" end,
+                providesCode = function(self, code) return (code == "First") and 1 or 0 end,
+            }
+            trampoline.CanProvideCodeFunc = invokeCanProvideCode
+            trampoline.ProvidesCodeFunc = invokeProvidesCode
+        end
+        function swapTrampolineState()
+            trampoline.ItemState = {
+                canProvideCode = function(self, code) return code == "Second" end,
+                providesCode = function(self, code) return (code == "Second") and 1 or 0 end,
+            }
+        end
+        function makeLateItem()
+            lateItem = ScriptHost:CreateLuaItem()
+            lateItem.Name = "late"
+        end
+        function giveLateItemCodes()
+            function lateItem:CanProvideCodeFunc(code)
+                return code == "Late"
+            end
+            function lateItem:ProvidesCodeFunc(code)
+                return (code == "Late") and 1 or 0
+            end
+        end
         function makeSecondItem()
             local other = ScriptHost:CreateLuaItem()
             other.Name = "other"
@@ -128,22 +161,37 @@ TEST(LuaItemProvidesTest, CanProvideCodeIsCached) {
     const int afterFirst = calls();
     EXPECT_GT(afterFirst, 0);
 
-    // resolving the same code through another call site reuses the scan
-    EXPECT_EQ(tracker.getItemByCode("Code").getName(), "test");
-    EXPECT_EQ(calls(), afterFirst);
-
-    // a state change invalidates, so the answers stay correct
+    // a state change drops _providerCountCache, but must not make us ask Lua again
     auto& item = tracker.getItemById(tracker.getItemByCode("Code").getID());
     EXPECT_TRUE(item.changeState(BaseItem::Action::Primary));
     EXPECT_EQ(tracker.ProviderCountForCode("Code"), 1);
     EXPECT_EQ(tracker.ProviderCountForCode("Other"), 0);
-    EXPECT_GT(calls(), afterFirst);
+    EXPECT_EQ(calls(), afterFirst);
 
     // adding an item has to invalidate the cache
     lua_getglobal(L, "makeSecondItem");
     ASSERT_EQ(lua_pcall(L, 0, 0, 0), LUA_OK) << lua_tostring(L, -1);
     EXPECT_TRUE(item.changeState(BaseItem::Action::Primary));
     EXPECT_EQ(tracker.ProviderCountForCode("Other"), 1);
+    EXPECT_GT(calls(), afterFirst);
+
+    // an item that declares its codes after creation must invalidate too
+    lua_getglobal(L, "makeLateItem");
+    ASSERT_EQ(lua_pcall(L, 0, 0, 0), LUA_OK) << lua_tostring(L, -1);
+    EXPECT_EQ(tracker.ProviderCountForCode("Late"), 0);
+    lua_getglobal(L, "giveLateItemCodes");
+    ASSERT_EQ(lua_pcall(L, 0, 0, 0), LUA_OK) << lua_tostring(L, -1);
+    EXPECT_EQ(tracker.ProviderCountForCode("Late"), 1);
+
+    // what answers canProvideCode may live in ItemState rather than in CanProvideCodeFunc
+    lua_getglobal(L, "makeTrampolineItem");
+    ASSERT_EQ(lua_pcall(L, 0, 0, 0), LUA_OK) << lua_tostring(L, -1);
+    EXPECT_EQ(tracker.ProviderCountForCode("First"), 1);
+    EXPECT_EQ(tracker.ProviderCountForCode("Second"), 0);
+    lua_getglobal(L, "swapTrampolineState");
+    ASSERT_EQ(lua_pcall(L, 0, 0, 0), LUA_OK) << lua_tostring(L, -1);
+    EXPECT_EQ(tracker.ProviderCountForCode("First"), 0);
+    EXPECT_EQ(tracker.ProviderCountForCode("Second"), 1);
 
     lua_close(L);
 }

--- a/test/core/test_luaitem.cpp
+++ b/test/core/test_luaitem.cpp
@@ -100,39 +100,6 @@ TEST(LuaItemProvidesTest, CanProvideCodeIsCached) {
             clicks = clicks + 1
             self.Icon = "icon" .. clicks  -- trigger onChange
         end
-        function makeTrampolineItem()
-            local function invokeCanProvideCode(item, code)
-                return item.ItemState:canProvideCode(code)
-            end
-            local function invokeProvidesCode(item, code)
-                return item.ItemState:providesCode(code)
-            end
-            trampoline = ScriptHost:CreateLuaItem()
-            trampoline.ItemState = {
-                canProvideCode = function(self, code) return code == "First" end,
-                providesCode = function(self, code) return (code == "First") and 1 or 0 end,
-            }
-            trampoline.CanProvideCodeFunc = invokeCanProvideCode
-            trampoline.ProvidesCodeFunc = invokeProvidesCode
-        end
-        function swapTrampolineState()
-            trampoline.ItemState = {
-                canProvideCode = function(self, code) return code == "Second" end,
-                providesCode = function(self, code) return (code == "Second") and 1 or 0 end,
-            }
-        end
-        function makeLateItem()
-            lateItem = ScriptHost:CreateLuaItem()
-            lateItem.Name = "late"
-        end
-        function giveLateItemCodes()
-            function lateItem:CanProvideCodeFunc(code)
-                return code == "Late"
-            end
-            function lateItem:ProvidesCodeFunc(code)
-                return (code == "Late") and 1 or 0
-            end
-        end
         function makeSecondItem()
             local other = ScriptHost:CreateLuaItem()
             other.Name = "other"
@@ -161,37 +128,22 @@ TEST(LuaItemProvidesTest, CanProvideCodeIsCached) {
     const int afterFirst = calls();
     EXPECT_GT(afterFirst, 0);
 
-    // a state change drops _providerCountCache, but must not make us ask Lua again
+    // resolving the same code through another call site reuses the scan
+    EXPECT_EQ(tracker.getItemByCode("Code").getName(), "test");
+    EXPECT_EQ(calls(), afterFirst);
+
+    // a state change invalidates, so the answers stay correct
     auto& item = tracker.getItemById(tracker.getItemByCode("Code").getID());
     EXPECT_TRUE(item.changeState(BaseItem::Action::Primary));
     EXPECT_EQ(tracker.ProviderCountForCode("Code"), 1);
     EXPECT_EQ(tracker.ProviderCountForCode("Other"), 0);
-    EXPECT_EQ(calls(), afterFirst);
+    EXPECT_GT(calls(), afterFirst);
 
     // adding an item has to invalidate the cache
     lua_getglobal(L, "makeSecondItem");
     ASSERT_EQ(lua_pcall(L, 0, 0, 0), LUA_OK) << lua_tostring(L, -1);
     EXPECT_TRUE(item.changeState(BaseItem::Action::Primary));
     EXPECT_EQ(tracker.ProviderCountForCode("Other"), 1);
-    EXPECT_GT(calls(), afterFirst);
-
-    // an item that declares its codes after creation must invalidate too
-    lua_getglobal(L, "makeLateItem");
-    ASSERT_EQ(lua_pcall(L, 0, 0, 0), LUA_OK) << lua_tostring(L, -1);
-    EXPECT_EQ(tracker.ProviderCountForCode("Late"), 0);
-    lua_getglobal(L, "giveLateItemCodes");
-    ASSERT_EQ(lua_pcall(L, 0, 0, 0), LUA_OK) << lua_tostring(L, -1);
-    EXPECT_EQ(tracker.ProviderCountForCode("Late"), 1);
-
-    // what answers canProvideCode may live in ItemState rather than in CanProvideCodeFunc
-    lua_getglobal(L, "makeTrampolineItem");
-    ASSERT_EQ(lua_pcall(L, 0, 0, 0), LUA_OK) << lua_tostring(L, -1);
-    EXPECT_EQ(tracker.ProviderCountForCode("First"), 1);
-    EXPECT_EQ(tracker.ProviderCountForCode("Second"), 0);
-    lua_getglobal(L, "swapTrampolineState");
-    ASSERT_EQ(lua_pcall(L, 0, 0, 0), LUA_OK) << lua_tostring(L, -1);
-    EXPECT_EQ(tracker.ProviderCountForCode("First"), 0);
-    EXPECT_EQ(tracker.ProviderCountForCode("Second"), 1);
 
     lua_close(L);
 }

--- a/test/core/test_luaitem.cpp
+++ b/test/core/test_luaitem.cpp
@@ -65,3 +65,82 @@ TEST(LuaItemProvidesTest, Simple) {
 
     lua_close(L);
 }
+
+TEST(LuaItemProvidesTest, CanProvideCodeIsCached) {
+    Pack pack("examples/async"); // doesn't matter which one
+    lua_State* L = luaL_newstate();
+    ASSERT_TRUE(L);
+
+    Tracker tracker(&pack, L);
+    Tracker::Lua_Register(L);
+    tracker.Lua_Push(L);
+    lua_setglobal(L, "Tracker");
+    lua_pushstring(L, "Pack");
+    lua_pushlightuserdata(L, &pack);
+    lua_settable(L, LUA_REGISTRYINDEX);
+    ScriptHost scriptHost(&pack, L, &tracker);
+    ScriptHost::Lua_Register(L);
+    scriptHost.Lua_Push(L);
+    lua_setglobal(L, "ScriptHost");
+    LuaItem::Lua_Register(L);
+
+    const char* script = R"(
+        calls = 0
+        local clicks = 0
+        local item = ScriptHost:CreateLuaItem()
+        item.Name = "test"
+        function item:CanProvideCodeFunc(code)
+            calls = calls + 1
+            return code == "Code"
+        end
+        function item:ProvidesCodeFunc(code)
+            return (code == "Code") and 1 or 0
+        end
+        function item:OnLeftClickFunc()
+            clicks = clicks + 1
+            self.Icon = "icon" .. clicks  -- trigger onChange
+        end
+        function makeSecondItem()
+            local other = ScriptHost:CreateLuaItem()
+            other.Name = "other"
+            function other:CanProvideCodeFunc(code)
+                return code == "Other"
+            end
+            function other:ProvidesCodeFunc(code)
+                return (code == "Other") and 1 or 0
+            end
+        end
+    )";
+    const char* modName = "script";
+    ASSERT_EQ(luaL_loadbufferx(L, script, strlen(script), modName, "t"), LUA_OK);
+    lua_pushstring(L, modName);
+    ASSERT_EQ(lua_pcall(L, 1, 1, 0), LUA_OK) << lua_tostring(L, -1);
+
+    auto calls = [L]() {
+        lua_getglobal(L, "calls");
+        const int n = (int)lua_tointeger(L, -1);
+        lua_pop(L, 1);
+        return n;
+    };
+
+    EXPECT_EQ(tracker.ProviderCountForCode("Code"), 1);
+    EXPECT_EQ(tracker.ProviderCountForCode("Other"), 0);
+    const int afterFirst = calls();
+    EXPECT_GT(afterFirst, 0);
+
+    // a state change drops _providerCountCache, but must not make us ask Lua again
+    auto& item = tracker.getItemById(tracker.getItemByCode("Code").getID());
+    EXPECT_TRUE(item.changeState(BaseItem::Action::Primary));
+    EXPECT_EQ(tracker.ProviderCountForCode("Code"), 1);
+    EXPECT_EQ(tracker.ProviderCountForCode("Other"), 0);
+    EXPECT_EQ(calls(), afterFirst);
+
+    // adding an item has to invalidate the cache
+    lua_getglobal(L, "makeSecondItem");
+    ASSERT_EQ(lua_pcall(L, 0, 0, 0), LUA_OK) << lua_tostring(L, -1);
+    EXPECT_TRUE(item.changeState(BaseItem::Action::Primary));
+    EXPECT_EQ(tracker.ProviderCountForCode("Other"), 1);
+    EXPECT_GT(calls(), afterFirst);
+
+    lua_close(L);
+}

--- a/test/core/test_luaitem.cpp
+++ b/test/core/test_luaitem.cpp
@@ -100,6 +100,18 @@ TEST(LuaItemProvidesTest, CanProvideCodeIsCached) {
             clicks = clicks + 1
             self.Icon = "icon" .. clicks  -- trigger onChange
         end
+        function makeLateItem()
+            lateItem = ScriptHost:CreateLuaItem()
+            lateItem.Name = "late"
+        end
+        function giveLateItemCodes()
+            function lateItem:CanProvideCodeFunc(code)
+                return code == "Late"
+            end
+            function lateItem:ProvidesCodeFunc(code)
+                return (code == "Late") and 1 or 0
+            end
+        end
         function makeSecondItem()
             local other = ScriptHost:CreateLuaItem()
             other.Name = "other"
@@ -141,6 +153,14 @@ TEST(LuaItemProvidesTest, CanProvideCodeIsCached) {
     EXPECT_TRUE(item.changeState(BaseItem::Action::Primary));
     EXPECT_EQ(tracker.ProviderCountForCode("Other"), 1);
     EXPECT_GT(calls(), afterFirst);
+
+    // an item that declares its codes after creation must invalidate too
+    lua_getglobal(L, "makeLateItem");
+    ASSERT_EQ(lua_pcall(L, 0, 0, 0), LUA_OK) << lua_tostring(L, -1);
+    EXPECT_EQ(tracker.ProviderCountForCode("Late"), 0);
+    lua_getglobal(L, "giveLateItemCodes");
+    ASSERT_EQ(lua_pcall(L, 0, 0, 0), LUA_OK) << lua_tostring(L, -1);
+    EXPECT_EQ(tracker.ProviderCountForCode("Late"), 1);
 
     lua_close(L);
 }


### PR DESCRIPTION
### Before you look at the code please read the disclaimer

The code in this PR was entirely created by Claude Opus 4.8. I have tested it in the past two days and could find no regressions. I had Vyneras, Stripes007, and GerbilJames look over it who all don't know the PopTracker code base well but confirmed it looks okay.

I looked for you, BlackSliver, mentioning what you think of AI contributions and found this message from almost exactly one year back: https://discord.com/channels/937157230963339364/937174275478138900/1398299243961389127
In it you said "it's not fully vibe-coded / complete AI slop; I don't think asking AI for help is a problem, but letting AI write it all is". So this is me letting know **this is fully written by AI**. I don't think it's slop because it works and my - and other's - tests (playing with it) couldn't find issues with it. So this is why I am making this PR. You can close it though if you still do not want to include it in this codebase - this is why I wrote the disclaimer before you look at the code so any code you write won't be influenced.


**Why this was needed:**
I am currently implementing Entrance Randomisation in Pokémon Crystal with every Entrance being a LuaItem. It is based on Stripes007' ER-integration of ALTTP. There, the issue wasn't as stark but Crystal has a multitude more entrances so once all my Lua Items are loaded, every toggle introduces about 0.5s-1s delay between the click and poptracker reacting (image turning gray for example). I tried mitigating the issue from a pack-perspective and it got a bit better but it only could do so much. That's when I found the ``TODO: cache lua items for performance increases`` comment and had Claude make this. And it worked. Currently Vyneras is also implementing ER independently in the FRLG-pack and has hit the same issue as me - and also confirmed that the build I made fixes the issue without any apparent regressions.

You can find a compiled build here: https://github.com/palex00/PopTracker/actions/runs/29664239904

So even if you don't accept the AI-code, please, we need this features, we can't release our packs like this lmao D:


I have asked Claude to write up a PR text. All the text above was written by me, everything below this by AI. 


Summary
-------

LuaItem::canProvideCode is a lua_pcall per call and is not cached (there is a
"TODO: cache result for performance reasons" on it in luaitem.cpp). Every code
resolution scans all Lua items, so the cost of resolving one code is one call
into Lua per Lua item:

- Tracker::ProviderCountForCode sums over _luaItems and cannot short-circuit
- Tracker::FindObjectForCode scans _luaItems on an _objectCache miss
- Tracker::getItemByCode scans _luaItems and is not cached at all

_providerCountCache is dropped on every item change, so the full sweep recurs on
every toggle. This is fine for packs with a handful of Lua items and becomes
quadratic for packs that use a lot of them.

This PR caches the code -> providing-Lua-items mapping in the Tracker and uses
it at those three call sites.

Measurement
-----------

Found while working on a Pokemon Crystal AP pack that creates one Lua item per
randomizable entrance (up to 856 for a full entrance shuffle). Counting calls
into canProvideCode from the pack side, per item toggle:

  56948 canProvideCode calls / 619 distinct codes / 92 items

56948 = 619 x 92 exactly. The cost is (codes resolved per state change) x
(number of Lua items). The 619 codes are that pack's hosted_item codes plus its
visibility_rules codes, both re-resolved on every state change because
_providerCountCache was just cleared.

At 856 Lua items that is ~530k lua_pcalls per toggle, about half a second of lag
on every click. With this PR the scan happens once per code and then never
again, and the lag is gone.

Secondary effect: because those callbacks run inside the enclosing function's
instruction budget (DEFAULT_EXEC_LIMIT), the same pack was hitting
"Execution aborted. Limit reached." in access rules. That also stops.

Why caching across state changes is correct
-------------------------------------------

canProvideCode is defined as "can this item ever provide this code" - it is
state-independent by contract. Current value is expressed through providesCode,
which is still called every time and is not cached here.

There is precedent: _objectCache already caches the code -> item mapping for the
entire load, and is only cleared when items or locations are added.

So this cache is invalidated in exactly the places _objectCache is:
AddItems, AddLocations and CreateLuaItem.

Extra invalidation was needed for the item's own definition. CreateLuaItem clears
the caches *before* the pack assigns the code-answering functions, and those
setters emit nothing, so an item created lazily at runtime could be cached as a
non-provider forever. LuaItem now emits a new onCodesChanged signal, and the
Tracker drops _luaProviderCache, _providerCountCache and _objectCache on it.

It is emitted from two setters, not one:

- CanProvideCodeFunc, the obvious case
- ItemState, because the widespread custom-item pattern installs a fixed
  trampoline as CanProvideCodeFunc:

      local function invokeCanProvideCode(item, code)
          return item.ItemState:canProvideCode(code)
      end

  For those items CanProvideCodeFunc never changes after construction and the
  real answer comes from ItemState, so swapping ItemState changes which codes
  the item provides with no other observable event.

_objectCache is included in that invalidation because it has the same exposure:
it maps a code to the first item that claimed it, and nothing re-checked that if
the item later stopped providing it. That is pre-existing, but it would be odd to
have a signal that says "this item's codes changed" and not act on it.

Behaviour change / review note
------------------------------

This is the part worth scrutinising: a pack whose canProvideCode answer changes
over time will now see the old answer until an invalidation point is hit.
Previously ProviderCountForCode re-asked on every resolution.

Such a pack is already inconsistent with _objectCache, which would keep handing
out the first item that ever claimed the code, so I do not think this is a
supported pattern. But it is a real difference and I would rather flag it than
have it found later. If you would prefer a narrower lifetime, dropping the cache
on any Lua item change instead is a one-line change - it just gives up most of
the benefit during autotracking bursts.

Implementation notes
--------------------

- Tracker::luaProvidersForCode(code) does the scan once and memoises it. The
  member is mutable so getItemByCode can stay const.
- ProviderCountForCode takes a copy of the provider list, because providesCode
  re-enters Lua and could invalidate the cache underneath the iteration.
- FindObjectForCode needs one const_cast to build the Object; the cache stores
  const LuaItem* so that the const getItemByCode can share it.
- I removed the "TODO: cache result" comment on canProvideCode, since the cost it
  refers to is now handled - but note the cache sits in the Tracker rather than in
  LuaItem, and ScriptHost's watch dispatch still calls canProvideCode directly,
  once per registered code watch per state change. That path is bounded by the
  number of watches rather than the number of items, so I left it alone. Happy to
  keep the comment if you would rather track that separately.

Tests
-----

test/core/test_luaitem.cpp gains LuaItemProvidesTest.CanProvideCodeIsCached,
which counts CanProvideCodeFunc invocations from Lua and asserts:

- a state change does not cause canProvideCode to be asked again
- creating an item invalidates the cache
- an item that assigns CanProvideCodeFunc after creation invalidates it too
- an item using the ItemState trampoline pattern picks up a swapped ItemState

The existing LuaItemProvidesTest.Simple covers that observable behaviour is
unchanged.
