### PR TITLE
LuaItem: add PotentialCodes

### DIFF
--- a/api/lua/definition/poptracker.lua
+++ b/api/lua/definition/poptracker.lua
@@ -555,6 +555,12 @@ LuaItem.Owner = {}
 ---@type string
 LuaItem.Type = "custom"
 
+---Array (table) of all possible codes the item can provide (since 0.35.4).
+---Implement CanProvideCodeFunc for backwards compatibility. Set to nil to always call CanProvideCodeFunc.
+---Note: LuaItems have to be created before the corresponding layout is loaded.
+---@type string[]?
+LuaItem.PotentialCodes = nil
+
 ---Called to match item to code (to place it in layouts).
 ---Note: LuaItems have to be created before the corresponding layout is loaded.
 ---@type fun(self:LuaItem, code:string):boolean

--- a/doc/PACKS.md
+++ b/doc/PACKS.md
@@ -191,11 +191,12 @@ a table representing an enum with the following constants: \
 * `string .IconMods`: icon modifier, see JSON's img_mods. Only available in PopTracker, since 0.11.0
 * `string .Name`: item's name
 * `object .ItemState`: (any) object to track internal state in Lua. Keys have to be strings for Get and Set below to work.
+* `string[]? .PotentialCodes`: array (table) of all possible codes the item can provide, since 0.35.4. See CanProvideCodeFunc for backwards compatibility.
 * `closure(LuaItem) .OnLeftClickFunc`: called when left-clicking
 * `closure(LuaItem) .OnRightClickFunc`: called when right-clicking
 * `closure(LuaItem) .OnMiddleClickFunc`: called when middle-clicking, since 0.25.8
 * **TODO**: Forward, Backward or a generalized onClick(button)
-* `closure(LuaItem,string code) .CanProvideCodeFunc`: called to determine if item has code
+* `closure(LuaItem,string code) .CanProvideCodeFunc`: called to determine if item can have a code, unless `PotentialCodes` is set to a table.
 * `closure(LuaItem,string code) .ProvidesCodeFunc`: called to track progress, closure should return 1 if code is provided (can provide && active)
 * `closure(LuaItem,string code) .AdvanceToCodeFunc`: called to change item's stage to provide code (not in use yet)
 * `closure(LuaItem) .SaveFunc`: called when saving, closure should return a lua object that works in LoadFunc

--- a/src/core/luaitem.cpp
+++ b/src/core/luaitem.cpp
@@ -85,7 +85,14 @@ int LuaItem::Lua_Index(lua_State *L, const char* key) {
         lua_pushstring(L, Type2Str(_type).c_str());
         return 1;
     }
-    
+    if (strcmp(key, "PotentialCodes") == 0) {
+        if (!_potentialCodes.has_value())
+            lua_pushnil(L);
+        else
+            json_to_lua(L, _potentialCodes.value());
+        return 1;
+    }
+
     return 0;
 }
 
@@ -170,6 +177,27 @@ bool LuaItem::Lua_NewIndex(lua_State *L, const char *key) {
     } else if (strcmp(key,"MaskInput")==0) {
         return true; // FIXME: not implemented
     }
+    if (strcmp(key, "PotentialCodes") == 0) {
+        if (lua_istable(L, -1)) {
+            _potentialCodes.emplace();
+            const lua_Integer n = luaL_len(L, -1);
+            _potentialCodes->reserve(static_cast<size_t>(n));
+            for (lua_Integer i = 1; i <= n; i++) {
+                if (lua_geti(L, -1, i) == LUA_TNIL)
+                    break; // TODO: readable error?
+                _potentialCodes->emplace_back(lua_tostring(L, -1));
+                lua_pop(L, 1);
+            }
+        } else if (lua_isnil(L, -1)) {
+            _potentialCodes.reset();
+        } else {
+            const std::string msg = std::string("Unsupported type for \"") + key
+                    + "\" of \"" + Lua_Name + "\". Expected table or nil.";
+            luaL_error(L, msg.c_str());
+            return false;
+        }
+        return true;
+    }
 
     return false;
 }
@@ -177,9 +205,11 @@ bool LuaItem::Lua_NewIndex(lua_State *L, const char *key) {
 
 bool LuaItem::canProvideCode(const std::string& code) const
 {
-    // TODO: cache result for performance reasons
+    if (_potentialCodes.has_value())
+        return std::find(_potentialCodes->begin(), _potentialCodes->end(), code) != _potentialCodes->end();
     if (!_canProvideCodeFunc.valid())
         return false;
+    // TODO: cache result for performance reasons?
     lua_rawgeti(_L, LUA_REGISTRYINDEX, _canProvideCodeFunc.ref);
     Lua_Push(_L); // arg1: this
     lua_pushstring(_L, code.c_str()); // arg2: code

--- a/src/core/luaitem.h
+++ b/src/core/luaitem.h
@@ -1,11 +1,13 @@
 #pragma once
 
-#include <string>
 #include <list>
-#include <nlohmann/json.hpp>
-#include "baseitem.h"
+#include <optional>
+#include <string>
+#include <vector>
 #include <luaglue/luainterface.h>
 #include <luaglue/luavariant.h>
+#include <nlohmann/json.hpp>
+#include "baseitem.h"
 
 
 class LuaItem final : public LuaInterface<LuaItem>, public BaseItem {
@@ -96,7 +98,8 @@ public:
     
 private:
     lua_State *_L = nullptr; // FIXME: fix this
-    
+
+    std::optional<std::vector<std::string>> _potentialCodes; // vector should be faster than set for the common cases
     LuaRef _itemState;
     LuaRef _onLeftClickFunc;
     LuaRef _onRightClickFunc;

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -171,7 +171,8 @@ int Tracker::runLuaFunction(lua_State* L, const std::string name, int &out)
     return callStatus;
 }
 
-bool Tracker::AddItems(const std::string& file) {
+bool Tracker::AddItems(const std::string& file)
+{
     printf("Loading items from \"%s\"...\n", file.c_str());
     std::string s;
     if (!_pack->ReadFile(file, s)) {
@@ -179,8 +180,13 @@ bool Tracker::AddItems(const std::string& file) {
         fprintf(stderr, "WARNING: unable to read file\n");
         return false;
     }
+    return AddItemsFromString(s);
+}
+
+bool Tracker::AddItemsFromString(std::string& s)
+{
     json j = parse_jsonc(s);
-    
+
     if (j.type() != json::value_t::array) {
         fprintf(stderr, "Bad json\n"); // TODO: throw lua error?
         return false;

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -64,8 +64,9 @@ public:
         }
     };
     
-    
+
     bool AddItems(const std::string& file);
+    bool AddItemsFromString(std::string& s);
     bool AddLocations(const std::string& file);
     bool AddMaps(const std::string& file);
     bool AddLayouts(const std::string& file);

--- a/test/core/test_luaitem.cpp
+++ b/test/core/test_luaitem.cpp
@@ -65,3 +65,54 @@ TEST(LuaItemProvidesTest, Simple) {
 
     lua_close(L);
 }
+
+TEST(LuaItemProvidesTest, PotentialCodes) {
+    Pack pack("examples/async"); // doesn't matter which one
+    lua_State* L = luaL_newstate();
+    luaL_requiref(L, LUA_GNAME, luaopen_base, 1); // for error()
+    lua_pop(L, 1);
+    ASSERT_TRUE(L);
+
+    Tracker tracker(&pack, L);
+    Tracker::Lua_Register(L);
+    tracker.Lua_Push(L);
+    lua_setglobal(L, "Tracker");
+    lua_pushstring(L, "Pack");
+    lua_pushlightuserdata(L, &pack);
+    lua_settable(L, LUA_REGISTRYINDEX);
+    ScriptHost scriptHost(&pack, L, &tracker);
+    ScriptHost::Lua_Register(L);
+    scriptHost.Lua_Push(L);
+    lua_setglobal(L, "ScriptHost");
+    LuaItem::Lua_Register(L);
+
+    const char* script = R"(
+        local item = ScriptHost:CreateLuaItem()
+        item.Name = "test"
+        item.PotentialCodes = {"Something", "Code"}
+        function item:CanProvideCodeFunc(code)
+            return code == "Not" -- we should never run this function
+        end
+        if type(item.PotentialCodes) ~= "table" then
+            error("Error setting or getting PotentialCodes: wrong type")
+        end
+        if item.PotentialCodes[1] ~= "Something"
+                or item.PotentialCodes[2] ~= "Code"
+                or item.PotentialCodes[3] ~= nil then
+            error("Error setting or getting PotentialCodes: values don't match")
+        end
+    )";
+    const char* modName = "script";
+    ASSERT_EQ(luaL_loadbufferx(L, script, strlen(script), modName, "t"), LUA_OK);
+    lua_pushstring(L, modName);
+    ASSERT_EQ(lua_pcall(L, 1, 1, 0), LUA_OK) << lua_tostring(L, -1);
+
+    auto& item = tracker.getItemById(tracker.getItemByCode("Code").getID());
+
+    EXPECT_TRUE(item.canProvideCode("Something"));
+    EXPECT_TRUE(item.canProvideCode("Code"));
+    EXPECT_FALSE(item.canProvideCode("Not"));
+    EXPECT_EQ(item.providesCode("Code"), 0);
+
+    lua_close(L);
+}


### PR DESCRIPTION
as a better performing alternative to CanProvideCodeFunc that's easier to optimize further.

Instead of having the rules call into tons of Lua functions for each code that is being checked, the LuaItem can tell the resolver which codes the item can provide.

Also adds `bool Tracker::AddItemsFromString(std::string& s)` which was used in performance testing. Sadly the tests themselves are not ready to be merged.