### PR TITLE
Fix, JsonItem: fall back to img if disabled_img is invalid

### DIFF
--- a/src/ui/trackerview.cpp
+++ b/src/ui/trackerview.cpp
@@ -145,10 +145,22 @@ Item* TrackerView::makeItem(int x, int y, int width, int height, const ::BaseIte
             auto badgeFilters = imageModsToFilters(_tracker, badgeMods);
             w->addStage(1, m, std::make_unique<PackImageFuture>(pack, f), f, badgeFilters);
             if (n == 0 && m != 0) {
-                f = item->getDisabledImage(0);
+                const auto& disF = item->getDisabledImage(0);
                 const auto& disMods = item->getDisabledImageMods(0);
                 filters = imageModsToFilters(_tracker, disMods);
-                w->addStage(0, 0, std::make_unique<PackImageFuture>(pack, f), f, filters);
+                std::unique_ptr<PackImageFuture> future;
+                if (f == disF) {
+                    future = std::make_unique<PackImageFuture>(pack, f);
+                } else {
+                    future = std::make_unique<PackImageFuture>(pack, disF);
+                    if (future->getSize().width < 1) {
+                        // Invalid disable_img. Fall back to normal img.
+                        future = std::make_unique<PackImageFuture>(pack, f);
+                    } else {
+                        f = disF;
+                    }
+                }
+                w->addStage(0, 0, std::move(future), f, filters);
                 badgeMods = disMods;
                 badgeMods.push_back("overlay|" + origItem.getImage(0));
                 badgeFilters = imageModsToFilters(_tracker, badgeMods);
@@ -158,12 +170,21 @@ Item* TrackerView::makeItem(int x, int y, int width, int height, const ::BaseIte
         else if (disabled) {
             w->addStage(1, n, std::make_unique<PackImageFuture>(pack, f), f, filters);
             const auto& disF = item->getDisabledImage(n);
-            if (f != disF) {
-                f = disF;
+            std::unique_ptr<PackImageFuture> future;
+            if (f == disF) {
+                future = std::make_unique<PackImageFuture>(pack, f);
+            } else {
+                future = std::make_unique<PackImageFuture>(pack, disF);
+                if (future->getSize().width < 1) {
+                    // Invalid disable_img. Fall back to normal img.
+                    future = std::make_unique<PackImageFuture>(pack, f);
+                } else {
+                    f = disF;
+                }
             }
             const auto& disMods = item->getDisabledImageMods(n);
             filters = imageModsToFilters(_tracker, disMods);
-            w->addStage(0, n, std::make_unique<PackImageFuture>(pack, f), f, filters);
+            w->addStage(0, n, std::move(future), f, filters);
         }
         else {
             w->addStage(1, n, std::make_unique<PackImageFuture>(pack, f), f, filters);

--- a/test/ui/test_trackerview_makeitem.cpp
+++ b/test/ui/test_trackerview_makeitem.cpp
@@ -1,0 +1,89 @@
+#include <memory>
+#include <gtest/gtest.h>
+
+#include "../../lib/luaglue/lua_include.h"
+#include "../../src/ui/item.h"
+#include "../../src/ui/trackerview.h"
+#include "../uilib/font_helper.h"
+
+using nlohmann::json;
+
+constexpr char PACK_PATH[] = "examples/rules_test";
+constexpr int RENDER_WIDTH = 32;
+constexpr int RENDER_HEIGHT = 32;
+
+class TestTrackerView : public Ui::TrackerView {
+public:
+    explicit TestTrackerView(Tracker* tracker)
+        : TrackerView(0, 0, 0, 0, tracker, "default", &fontStore)
+    {
+    }
+
+    std::unique_ptr<Ui::Item> itemFromJson(json&& j)
+    {
+        const auto item = JsonItem::FromJSON(j);
+        return std::unique_ptr<Ui::Item>(makeItem(0, 0, 0, 0, item, -1, -1));
+    }
+};
+
+static std::string getPixelData(const SDL_Surface* surface)
+{
+    return std::string(static_cast<const char*>(surface->pixels), surface->h * surface->pitch);
+}
+
+TEST(TrackerViewMakeItem, EmptyFallBackToImg)
+{
+    SDL_Surface* surface = SDL_CreateRGBSurface(0, RENDER_WIDTH, RENDER_HEIGHT, 32, 0, 0, 0, 0);
+    if (!surface)
+        throw std::runtime_error("failed to create surface");
+    SDL_Renderer* renderer = SDL_CreateSoftwareRenderer(surface);
+    if (!renderer) {
+        SDL_FreeSurface(surface);
+        throw std::runtime_error("failed to create renderer");
+    }
+    lua_State* L = luaL_newstate();
+
+    {
+        Pack pack(PACK_PATH);
+        Tracker tracker(&pack, L);
+        TestTrackerView v(&tracker);
+        const auto item1 = v.itemFromJson({
+            {"type", "toggle"},
+            {"img", "images/items/a.png"},
+            {"disabled_img", "images/items/b.png"},
+            {"disabled_img_mods", ""},
+        });
+        const auto item2 = v.itemFromJson({
+            {"type", "toggle"},
+            {"img", "images/items/a.png"},
+            {"disabled_img", ""},
+            {"disabled_img_mods", ""},
+        });
+
+        SDL_RenderClear(renderer);
+        item1->render(renderer, 0, 0);
+        const std::string data1Off = getPixelData(surface);
+
+        SDL_RenderClear(renderer);
+        item1->setStage(1, 0);
+        item1->render(renderer, 0, 0);
+        const std::string data1On = getPixelData(surface);
+
+        SDL_RenderClear(renderer);
+        item2->render(renderer, 0, 0);
+        const std::string data2Off = getPixelData(surface);
+
+        SDL_RenderClear(renderer);
+        item2->setStage(1, 0);
+        item2->render(renderer, 0, 0);
+        const std::string data2On = getPixelData(surface);
+
+        EXPECT_EQ(data1On, data2On) << "expected render of same img to be identical";
+        EXPECT_NE(data1On, data1Off) << "expected render of different img to be different";
+        EXPECT_EQ(data2On, data2Off) << "expected missing disabled_img to fall back to img";
+    }
+
+    lua_close(L);
+    SDL_DestroyRenderer(renderer);
+    SDL_FreeSurface(surface);
+}


### PR DESCRIPTION
This is expected behavior for compat with pre-existing packs and was maybe partially the case pre-0.35.2.