### PR TITLE
Faster getLocation by using deque

### DIFF
--- a/src/core/location.cpp
+++ b/src/core/location.cpp
@@ -37,7 +37,7 @@ bool Location::Lua_NewIndex([[maybe_unused]] lua_State *L, [[maybe_unused]] cons
 
 std::list<Location> Location::FromJSON(
     json& j,
-    const std::list<Location>& parentLookup,
+    const std::deque<Location>& parentLookup,
     bool glitchedScoutableAsGlitched,
     const std::list< std::list<std::string> >& prevAccessRules,
     const std::list< std::list<std::string> >& prevVisibilityRules,

--- a/src/core/location.h
+++ b/src/core/location.h
@@ -59,7 +59,7 @@ public:
 
     static std::list<Location> FromJSON(
         nlohmann::json& j,
-        const std::list<Location>& parentLookup,
+        const std::deque<Location>& parentLookup,
         bool glitchedScoutableAsGlitched = false,
         const std::list< std::list<std::string> >& parentAccessRules={},
         const std::list< std::list<std::string> >& parentVisibilityRules={},

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -127,7 +127,7 @@ protected:
     uint64_t _lastItemID=0;
     std::list<JsonItem> _jsonItems;
     std::list<LuaItem> _luaItems;
-    std::list<Location> _locations;
+    std::deque<Location> _locations;
     std::map<std::string, LayoutNode> _layouts;
     std::unordered_map<std::string, const LayoutClass> _classes;
     std::map<std::string, Map> _maps;


### PR DESCRIPTION
Since we don't pop from the list, we can use a deque instead of a list and still get stable memory locations. Deque has better caching behavior and the linear search is limited by memory access.