### PR TITLE
Added the CloverPit Archipelago to packlist, updated satisfactory_ap author

### DIFF
--- a/community-packs.json
+++ b/community-packs.json
@@ -144,7 +144,7 @@
         "description":  "The Satisfactory Archipelago PopTracker Pack."
     },
     "cloverpit_ap": {
-        "name": "CloverPit PopTracker",
+        "name": "CloverPit Archipelago",
         "author": "Snileaf, builder_script, PopTracker Discord Server Community",
         "platform": "PC",
         "homepage": "https://github.com/snileaf/CloverPit-poptracker",

--- a/community-packs.json
+++ b/community-packs.json
@@ -136,11 +136,20 @@
     },
     "satisfactory_ap": {
         "name": "Satisfactory PopTracker",
-        "author": "Snileaf, builder_script",
+        "author": "Snileaf, builder_script, Satisfactory Archipelago Community, PopTracker Discord Server Community",
         "platform": "PC",
         "homepage": "https://github.com/snileaf/Satisfactory-poptracker",
         "versions_url": "https://raw.githubusercontent.com/snileaf/Satisfactory-poptracker/versions/versions.json",
         "icon_url": "https://raw.githubusercontent.com/snileaf/Satisfactory-poptracker/versions/satisfactory-S.png",
         "description":  "The Satisfactory Archipelago PopTracker Pack."
+    },
+    "cloverpit_ap": {
+        "name": "CloverPit PopTracker",
+        "author": "Snileaf, builder_script, PopTracker Discord Server Community",
+        "platform": "PC",
+        "homepage": "https://github.com/snileaf/CloverPit-poptracker",
+        "versions_url": "https://raw.githubusercontent.com/snileaf/CloverPit-poptracker/versions/versions.json",
+        "icon_url": "https://raw.githubusercontent.com/snileaf/CloverPit-poptracker/versions/CloverPit.png",
+        "description":  "The CloverPit Archipelago PopTracker Pack."
     }
 }


### PR DESCRIPTION
Mainly because it was initially released without auto-tracking, and this will enable it for people on v0.0.1.