### PR TITLE
CI: enable dependabot on packlist branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,18 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    target-branch: "packlist"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    target-branch: "packlist"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 3
+      include:
+        - "*"


### PR DESCRIPTION
The docs are not very clear if it works like this.

What this hopefully does:
- keep version updates and security updates for main branch as-is
- also scan packlist for updates