### PR TITLE
Update inherit_codes explanation in PACKS.md

### DIFF
--- a/doc/PACKS.md
+++ b/doc/PACKS.md
@@ -302,14 +302,14 @@ a table representing an enum with the following constants: \
     - NOTE: order matters, applied left to right
   + inherit_codes: `true` (the default) will make a stage also provide all codes the previous stage provides.
     See the table below for an example.
-    | Stage    | Codes    | Inherit  | Resulting Codes |
-    | -------- | -------- | -------- | --------------- |
-    | 1        | a        | false    | a               |
-    | 2        | b        | false    | b               |
-    | 3        | c        | true     | b,c             |
-    | 4        | d        | true     | b,c,d           |
-    | 5        | e        | false    | e               |
-    | 6        | f        | true     | e,f             |
+    | Stage    | `codes`  | `inherit_codes` | Resulting Codes |
+    | -------- | -------- | --------------- | --------------- |
+    | 1        | a        | `false`         | a               |
+    | 2        | b        | `false`         | b               |
+    | 3        | c        | `true`          | b,c             |
+    | 4        | d        | `true`          | b,c,d           |
+    | 5        | e        | `false`         | e               |
+    | 6        | f        | `true`          | e,f             |
 
 * `"toggle"`:
   + only has on/off

--- a/doc/PACKS.md
+++ b/doc/PACKS.md
@@ -300,11 +300,8 @@ a table representing an enum with the following constants: \
     - `greyscale`: same as `saturation|0`; since 0.32.2
     - `grayscale`: same as `greyscale`; since 0.35.4
     - NOTE: order matters, applied left to right
-  + inherit_codes: codes from previous stage, and any codes the previous stage inherited, are applied. Stage1 cannot inherit codes as it is the lowest stage, so inherit_codes does not apply to it.  
-    For a 4 stage progressive item, if stage3 has `inherit_codes` as `true`, and stage1, stage2, and stage4 are `false`, stage3 will inherit codes from only stage2.
-    Stage1, stage2, and stage4 will not inherit any codes.  
-    If stage1, stage2, and stage3 have `inherit_codes` as `true`, and stage4 is `false`, stage1 will not inherit any codes as it is the lowest stage, stage2 will inherit codes from stage 1, stage3 will inherit
-    codes from stage1 and stage2, and stage4 not inherit any codes.
+  + inherit_codes: `true` (the default) will make a stage also provide all codes the previous stage provides.
+    See the table below for an example.
     | Stage    | Codes    | Inherit  | Resulting Codes |
     | -------- | -------- | -------- | --------------- |
     | 1        | a        | false    | a               |

--- a/doc/PACKS.md
+++ b/doc/PACKS.md
@@ -300,7 +300,19 @@ a table representing an enum with the following constants: \
     - `greyscale`: same as `saturation|0`; since 0.32.2
     - `grayscale`: same as `greyscale`; since 0.35.4
     - NOTE: order matters, applied left to right
-  + inherit_codes: true will make stage3 provide codes for item, stage1, 2 and 3 (default true)
+  + inherit_codes: codes from previous stage, and any codes the previous stage inherited, are applied. Stage1 cannot inherit codes as it is the lowest stage, so inherit_codes does not apply to it.  
+    For a 4 stage progressive item, if stage3 has `inherit_codes` as `true`, and stage1, stage2, and stage4 are `false`, stage3 will inherit codes from only stage2.
+    Stage1, stage2, and stage4 will not inherit any codes.  
+    If stage1, stage2, and stage3 have `inherit_codes` as `true`, and stage4 is `false`, stage1 will not inherit any codes as it is the lowest stage, stage2 will inherit codes from stage 1, stage3 will inherit
+    codes from stage1 and stage2, and stage4 not inherit any codes.
+    | Stage    | Codes    | Inherit  | Resulting Codes |
+    | -------- | -------- | -------- | --------------- |
+    | 1        | a        | false    | a               |
+    | 2        | b        | false    | b               |
+    | 3        | c        | true     | b,c             |
+    | 4        | d        | true     | b,c,d           |
+    | 5        | e        | false    | e               |
+    | 6        | f        | true     | e,f             |
 
 * `"toggle"`:
   + only has on/off

--- a/test/core/test_jsonitem_inherit_codes.cpp
+++ b/test/core/test_jsonitem_inherit_codes.cpp
@@ -1,0 +1,64 @@
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+#include "../../src/core/jsonitem.h"
+
+using namespace std;
+using nlohmann::json;
+
+
+/// test that progressive with inherit_codes follows documentation
+/// NOTE: "inherit_codes": true omitted from last stage to test default
+TEST(JsonItemInheritsCodesTest, DocumentationExample)
+{
+    using namespace std::literals::string_literals;
+
+    auto jDocumentationExample = R"(
+    {
+        "name": "item",
+        "type": "progressive",
+        "allow_disabled": false,
+        "stages": [
+            {
+                "name": "0",
+                "codes": "a",
+                "inherit_codes": false
+            },
+            {
+                "name": "1",
+                "codes": "b",
+                "inherit_codes": false
+            },
+            {
+                "name": "2",
+                "codes": "c",
+                "inherit_codes": true
+            },
+            {
+                "name": "3",
+                "codes": "d",
+                "inherit_codes": true
+            },
+            {
+                "name": "4",
+                "codes": "e",
+                "inherit_codes": false
+            },
+            {
+                "name": "5",
+                "codes": "f"
+            }
+        ]
+    }
+    )"_json;
+
+    auto item = JsonItem::FromJSON(jDocumentationExample);
+    const std::string allCodes = "abcdef";
+    ASSERT_EQ(std::string{'a'}, std::string("a"));
+    for (const auto& expected : {"a"s, "b"s, "bc"s, "bcd"s, "e"s, "ef"s}) {
+        for (char c: allCodes) {
+            EXPECT_EQ(item.providesCode({c}), expected.find(c) == std::string::npos ? 0 : 1)
+            << "for " << c << " at stage " << item.getActiveStage() << " expected " << expected;
+        }
+        item.changeState(BaseItem::Action::Next);
+    }
+}


### PR DESCRIPTION
Clarify behavior of inherit_codes in multi-stage items with examples. Mainly because the previous explanation, as Zeeveez put it, "suggests by omission it inherits from all previous stages w/o regard to their individual inherit code configs, but that's not the case". This adds a basic explanation, along with a written example with 2 different configs, and a logic table (made by Zeeveez).