### PR TITLE
Fix warning with GCC in DefaultTrackerWindow

### DIFF
--- a/src/ui/defaulttrackerwindow.cpp
+++ b/src/ui/defaulttrackerwindow.cpp
@@ -370,9 +370,11 @@ void DefaultTrackerWindow::hideOpen()
 
 void DefaultTrackerWindow::showProgress(const std::string& text, int progress, int max)
 {
-    char percentText[5];
-    if (max>0) snprintf(percentText, 5, "%3u%%", upercent(progress, max));
-    else percentText[0] = 0;
+    char percentText[12];
+    if (max > 0)
+        snprintf(percentText, 12, "%3u%%", upercent(progress, max)); // TODO: fmt
+    else
+        percentText[0] = 0;
     std::string valuesText = format_bytes(progress) + "B";
     if (max) valuesText += " / " + format_bytes(max) + "B";
 


### PR DESCRIPTION
There is a warning that a uint could technically be longer than 3, which would cut part of the static string.

Leave a comment that we should switch to fmt to avoid this kind of thing.