### PR TITLE
packlist: add checklist

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,1 +1,3 @@
-When performing a review, apply the checks in the `/checklist.md` file.
+When performing a review of a change to `/community-packs.json`, apply the checks in the `/checklist.md` file.
+
+Only consider added and changed lines, ignore unchanged lines.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+When performing a review, apply the checks in the `/checlist.md` file.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,1 +1,1 @@
-When performing a review, apply the checks in the `/checlist.md` file.
+When performing a review, apply the checks in the `/checklist.md` file.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ List of packs and their update URLs provided by the community.
 Send PRs for `community-packs.json` on GitHub to add your pack or remove a pack with wrong or outdated authorship.
 You can use the pencil button to create a PR directly on GitHub.
 
+Follow the [checklist](./checklist.md) to make the review quicker.
+
 ## packs.json
 
 The list of uid -> pack info. Links should point directly to the file/download.

--- a/checklist.md
+++ b/checklist.md
@@ -1,6 +1,6 @@
 # PopTracker Pack List Checklist
 
-When changing or adding a pack to a packlist (e.g. [community-packs.json](./community-packs.json)),
+When changing or adding a pack to a packlist (e.g. [`community-packs.json`](./community-packs.json)),
 make sure to verify the following:
 
 * The new key in the top level object matches the `package_uid` in the `manifest.json` of packs that should be upgraded:

--- a/checklist.md
+++ b/checklist.md
@@ -1,0 +1,15 @@
+# PopTracker Pack List Checklist
+
+When changing or adding a pack to a packlist (e.g. [community-packs.json](./community-packs.json)),
+make sure to verify the following:
+
+* The new key in the top level object matches the `package_uid` in the `manifest.json` of packs that should be upgraded:
+  Usually that means it is the same as all `package_uid`s of all `manifest.json`s of all downloads listed in the
+  linked versions json (`versions_url`). This may not be true if the `package_uid` changed at some point.
+* `versions_url` of changed/added objects starts with `https://` and points to a valid versions file.
+* `homepage` of changed/added objects starts with `https://` and points to a valid website.
+* `icon_url` of changed/added objects starts with `https://` and points to a valid PNG (preferred) or JPEG, not WEBP.
+* `name`, `author` and `platform` of changed/added objects match the properties of the `manifest.json` in the latest
+  download (highest version number) in the linked versions json (`versions_url`).
+* The proposed changes result in a valid JSON file (no extra or missing `,`).
+* You are the author of the pack or have permission to add the pack.


### PR DESCRIPTION
Adds a checklist for people to verify their PRs against packlist.

Also adds instructions that point copilot to the checklist in case people have that enabled for their PRs. (The default behaviour was kinda useless. The new behaviour may or may not be worth the tokens.)