### PR TITLE
CI: skip scan-build on Windows

### DIFF
--- a/.github/workflows/scan-build.yaml
+++ b/.github/workflows/scan-build.yaml
@@ -40,9 +40,10 @@ jobs:
           - os: ubuntu-latest
             shell: bash
             scan-build: scan-build-22
-          - os: windows-latest
-            shell: msys2 {0}
-            scan-build: scan-build
+          # scan-build broken in msys2 mingw-w64-x86_64
+          #- os: windows-latest
+          #  shell: msys2 {0}
+          #  scan-build: scan-build
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/scan-build.yaml
+++ b/.github/workflows/scan-build.yaml
@@ -77,6 +77,7 @@ jobs:
             mingw64/mingw-w64-x86_64-openssl
             mingw64/mingw-w64-x86_64-gtest
             mingw64/mingw-w64-x86_64-clang-analyzer
+            mingw64/mingw-w64-x86_64-perl
             p7zip
       - name: Install newer Clang and scan-build command (ubuntu)
         if: ${{ startsWith(matrix.os, 'ubuntu') }}


### PR DESCRIPTION
scan-build seems to be currently broken in msys2 mingw-w64-x86_64.

* Install Perl for scan-build on windows, since that dependency may be missing
* Disable scan-build on Windows for now