### PR TITLE
CI: timeouts and naming

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -57,6 +57,7 @@ jobs:
         echo "ARCH=$ARCH" >> $GITHUB_ENV
         echo "UNAME=$OS-$ARCH" >> $GITHUB_ENV
     - name: Install dependencies
+      timeout-minutes: 5
       run: |
         sudo apt-get update -y -qq
         sudo apt-get install coreutils build-essential libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev p7zip libgtest-dev libgmock-dev
@@ -102,6 +103,7 @@ jobs:
         echo "ARCH=$ARCH" >> $GITHUB_ENV
         echo "UNAME=$OS-$ARCH" >> $GITHUB_ENV
     - name: Install dependencies
+      timeout-minutes: 5
       run: |
         sudo apt-get update -y -qq
         sudo apt-get install coreutils build-essential libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev p7zip wget libgtest-dev libgmock-dev
@@ -191,6 +193,7 @@ jobs:
         echo "ARCH=$ARCH" >> $GITHUB_ENV
         echo "UNAME=$OS-$ARCH" >> $GITHUB_ENV
     - name: Install dependencies
+      timeout-minutes: 5
       run: |
         brew install coreutils SDL2 sdl2_ttf sdl2_image openssl@3.0 automake googletest || true
         # required, but pre-installed: libtool autoconf
@@ -294,6 +297,7 @@ jobs:
       run: |
         echo "UNAME=win64" >> $GITHUB_ENV
     - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884  # v2.32.0
+      timeout-minutes: 5
       with:
         update: true
         cache: ${{ github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/check-examples.yaml
+++ b/.github/workflows/check-examples.yaml
@@ -19,7 +19,8 @@ jobs:
 
   check-examples:
     runs-on: ubuntu-latest
-    
+    timeout-minutes: 5
+
     steps:
       - uses: actions/checkout@v7.0.1
         with:

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -10,6 +10,7 @@ jobs:
   codespell:
     runs-on: ubuntu-latest
     name: Find typos
+    timeout-minutes: 5
 
     steps:
     - uses: actions/checkout@v7.0.1

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -1,4 +1,4 @@
-name: Codespell
+name: Find typos
 
 on:
   push:
@@ -9,7 +9,6 @@ permissions: {}
 jobs:
   codespell:
     runs-on: ubuntu-latest
-    name: Find typos
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -13,10 +13,12 @@ jobs:
 
     steps:
       - name: Install dependencies (apt)
+        timeout-minutes: 5
         run: |
           sudo apt-get update -y -qq
           sudo apt-get install coreutils build-essential libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libgtest-dev libgmock-dev
       - name: Install newer Clang (ubuntu)
+        timeout-minutes: 5
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x ./llvm.sh

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,6 +17,8 @@ jobs:
   trigger_github_io_update:
     # NOTE: we use workflow_dispatch because repository_dispatch needs contents: write permissions
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
       - name: Delay
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,6 +65,7 @@ jobs:
 
     steps:
     - name: Install dependencies
+      timeout-minutes: 5
       run: |
         sudo apt-get update -y -qq
         sudo apt-get install coreutils build-essential libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev p7zip wget libgtest-dev libgmock-dev
@@ -154,6 +155,7 @@ jobs:
 
     steps:
     - name: Install dependencies
+      timeout-minutes: 5
       run: |
         sudo apt-get update -y -qq
         sudo apt-get install coreutils build-essential libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev p7zip wget libgtest-dev libgmock-dev
@@ -204,6 +206,7 @@ jobs:
 
     steps:
     - name: Install dependencies
+      timeout-minutes: 5
       run: |
         brew install coreutils SDL2 sdl2_ttf sdl2_image openssl@3.0 automake googletest || true
         # required, but pre-installed: libtool autoconf
@@ -290,6 +293,7 @@ jobs:
 
     steps:
     - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884  # v2.32.0
+      timeout-minutes: 5
       with:
         cache: false
         update: true

--- a/.github/workflows/scan-build.yaml
+++ b/.github/workflows/scan-build.yaml
@@ -57,11 +57,13 @@ jobs:
           submodules: recursive
       - name: Install dependencies (apt)
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        timeout-minutes: 5
         run: |
           sudo apt-get update -y -qq
           sudo apt-get install coreutils build-essential libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libgtest-dev libgmock-dev
       - name: Install dependencies (msys2)
         if: ${{ startsWith(matrix.os, 'windows') }}
+        timeout-minutes: 5
         uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884  # v2.32.0
         with:
           release: false
@@ -82,6 +84,7 @@ jobs:
             p7zip
       - name: Install newer Clang and scan-build command (ubuntu)
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        timeout-minutes: 5
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x ./llvm.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,19 +59,23 @@ jobs:
     steps:
     - name: Install dependencies (apt)
       if: ${{ startsWith(matrix.os, 'ubuntu') }}
+      timeout-minutes: 5
       run: |
         sudo apt-get update -y -qq
         sudo apt-get install coreutils build-essential libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libgtest-dev libgmock-dev
     - name: Install dependencies (brew)
       if: ${{ startsWith(matrix.os, 'macos') }}
+      timeout-minutes: 5
       run: |
         brew install coreutils SDL2 sdl2_ttf sdl2_image openssl@3.0 googletest || true
     - name: Install extra dependencies (brew)
       if: ${{ startsWith(matrix.os, 'macos') && contains(matrix.extra_make_args, 'MACOS_DEPLOYMENT_TARGET') }}
+      timeout-minutes: 5
       run: |
         brew install boost || true
     - name: Install dependencies (msys2, x86_64)
       if: ${{ startsWith(matrix.os, 'windows') && !endsWith(matrix.os, 'arm')}}
+      timeout-minutes: 5
       uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884  # v2.32.0
       with:
         release: false
@@ -90,6 +94,7 @@ jobs:
           p7zip
     - name: Install dependencies (msys2, arm)
       if: ${{ startsWith(matrix.os, 'windows') && endsWith(matrix.os, 'arm')}}
+      timeout-minutes: 5
       uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884  # v2.32.0
       with:
         msystem: CLANGARM64
@@ -141,6 +146,7 @@ jobs:
       with:
         submodules: recursive
     - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24
+      timeout-minutes: 5
       with:
         nix_path: nixpkgs=channel:nixos-25.05
     - run: |

--- a/.github/workflows/update-cacert.yaml
+++ b/.github/workflows/update-cacert.yaml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   update-cacert:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
       - uses: actions/checkout@v7.0.1
       - name: Check for cacert update


### PR DESCRIPTION
Runners have been hanging lately.

Combat this by adding timeouts to 'install' steps and job timeouts where there is no 'install' step.
If `apt`, `brew`, `msys` or `nix` won't finish in 5min, something is severely wrong with the runner or the network and it makes no sense to continue.

Also rename 'Codespell' workflow to 'Find Typos' - naming was the wrong way around compared to other workflows.