### PR TITLE
MapMarker: replace hint payload with JSON

### DIFF
--- a/doc/PACKS.md
+++ b/doc/PACKS.md
@@ -642,13 +642,48 @@ The following hint names are defined:
 * `"Zoom <MapName>[<n>]"`: same as above but for the nth instance starting at 0, since 0.34.0
 * `"Pan <MapName>"`: value = `"<center_x>,<center_y>"`, pan map to put specific pixel in the center, since 0.34.0
 * `"Pan <MapName>[<n>]"`: same as above but for the nth instance starting at 0, since 0.34.0
-* `"MapMarker <MapName>"`: value = `"<id>,<x>,<y>"` sets or moves the marker with id at the
-  image-space pixel coordinates x,y; value = `"<id>"` removes that marker. The marker remains a fixed
-  12-by-12 screen pixels while its center follows the map's zoom and pan, available since 0.36.0.
+* `"MapMarker <MapName>"`: value is a JSON object that sets, moves, or removes a transient marker. The
+  marker remains a fixed 12-by-12 screen pixels while its center follows the map's zoom and pan, available
+  since 0.36.0.
 * `"MapMarker <MapName>[<n>]"`: same as above but for the nth instance starting at 0. Without `[<n>]`,
   the hint updates every visible instance of the named map, available since 0.36.0.
 
-Marker coordinates may be fractional or outside the map image. Markers are transient UI state: they are
-cleared by `reset`, are not saved, and must be republished after a layout rebuild. Empty ids, ids containing
-commas, and values that are not exactly `"<id>"` or `"<id>,<x>,<y>"` with finite numeric coordinates are
-ignored without changing existing markers, available since 0.36.0.
+To set or replace a marker, provide an id and finite image-space coordinates:
+
+```json
+{
+  "id": "player",
+  "x": 414.5,
+  "y": 200.25
+}
+```
+
+The default appearance is a white diamond with a black border. A diamond may specify a fill color:
+
+```json
+{
+  "id": "player",
+  "x": 414.5,
+  "y": 200.25,
+  "appearance": {
+    "type": "diamond",
+    "color": "#ff0000"
+  }
+}
+```
+
+Colors are `#RRGGBB` or `#AARRGGBB`; the eight-digit form uses alpha first. To remove one marker, use an
+explicit removal object:
+
+```json
+{
+  "id": "player",
+  "remove": true
+}
+```
+
+Marker ids must be non-empty strings. Set operations require both `x` and `y`, and `appearance`, when
+provided, must contain `"type": "diamond"` with an optional valid color. Duplicate or unknown fields, wrong
+field types, non-finite or out-of-range coordinates, unsupported appearances, and malformed or ambiguous
+objects are ignored without changing existing marker state. Markers are transient UI state: they are cleared by
+`reset`, are not saved, and must be republished after a layout rebuild.

--- a/doc/PACKS.md
+++ b/doc/PACKS.md
@@ -642,3 +642,13 @@ The following hint names are defined:
 * `"Zoom <MapName>[<n>]"`: same as above but for the nth instance starting at 0, since 0.34.0
 * `"Pan <MapName>"`: value = `"<center_x>,<center_y>"`, pan map to put specific pixel in the center, since 0.34.0
 * `"Pan <MapName>[<n>]"`: same as above but for the nth instance starting at 0, since 0.34.0
+* `"MapMarker <MapName>"`: value = `"<id>,<x>,<y>"` sets or moves the marker with id at the
+  image-space pixel coordinates x,y; value = `"<id>"` removes that marker. The marker remains a fixed
+  12-by-12 screen pixels while its center follows the map's zoom and pan, available since 0.36.0.
+* `"MapMarker <MapName>[<n>]"`: same as above but for the nth instance starting at 0. Without `[<n>]`,
+  the hint updates every visible instance of the named map, available since 0.36.0.
+
+Marker coordinates may be fractional or outside the map image. Markers are transient UI state: they are
+cleared by `reset`, are not saved, and must be republished after a layout rebuild. Empty ids, ids containing
+commas, and values that are not exactly `"<id>"` or `"<id>,<x>,<y>"` with finite numeric coordinates are
+ignored without changing existing markers, available since 0.36.0.

--- a/src/ui/mapwidget.cpp
+++ b/src/ui/mapwidget.cpp
@@ -9,6 +9,8 @@ namespace Ui {
 static constexpr float ZOOM_IN_FACTOR = 1.25f;
 static constexpr float ZOOM_OUT_FACTOR = 0.8f;
 static constexpr float MAX_ZOOM = 1000.0f;
+static constexpr int MARKER_SIZE = 12;
+static constexpr int MARKER_BORDER_SIZE = 2;
 
 #define _DEFAULT_STATE_COLORS { \
     /* done */ \
@@ -390,6 +392,17 @@ void MapWidget::render(Renderer renderer, const int offX, const int offY)
         }
     }
 
+    const Color markerColor = {0xff, 0xff, 0xff, 0xff};
+    for (const auto& [id, marker] : _markers) {
+        (void)id;
+        float centerX, centerY;
+        calculateImagePointScreenPosition(marker.x, marker.y, srcRect, dstRect, centerX, centerY);
+        const int innerX = static_cast<int>(centerX - MARKER_SIZE / 2.0f);
+        const int innerY = static_cast<int>(centerY - MARKER_SIZE / 2.0f);
+        drawDiamond(renderer, {innerX, innerY}, {MARKER_SIZE, MARKER_SIZE}, MARKER_BORDER_SIZE,
+            markerColor, markerColor, markerColor, markerColor);
+    }
+
     // Restore clipping
     SDL_RenderSetClipRect(renderer, nullptr);
 }
@@ -472,6 +485,16 @@ void MapWidget::calculateSrcAndDst(const int offX, const int offY, const bool cl
     };
 }
 
+void MapWidget::calculateImagePointScreenPosition(const float x, const float y, const SDL_Rect& srcRect,
+    const SDL_FRect& dstRect, float& screenX, float& screenY)
+{
+    const float scale = dstRect.w / static_cast<float>(srcRect.w);
+    screenX = static_cast<float>(static_cast<int>(
+        (x - static_cast<float>(srcRect.x)) * scale)) + dstRect.x;
+    screenY = static_cast<float>(static_cast<int>(
+        (y - static_cast<float>(srcRect.y)) * scale)) + dstRect.y;
+}
+
 void MapWidget::calculateLocationScreenRect(const Point& pos, const SDL_Rect& srcRect, const SDL_FRect& dstRect,
     const float baseScale, int& innerX, int& innerY, int& innerW, int& innerH, int& borderSize)
 {
@@ -485,9 +508,11 @@ void MapWidget::calculateLocationScreenRect(const Point& pos, const SDL_Rect& sr
         borderSize = 1;
 
     // Calculate screen position based on image position
-    const float scale = static_cast<float>(dstRect.w) / static_cast<float>(srcRect.w);
-    innerX = static_cast<int>(static_cast<float>(pos.x - srcRect.x) * scale) + dstRect.x - innerW / 2;
-    innerY = static_cast<int>(static_cast<float>(pos.y - srcRect.y) * scale) + dstRect.y - innerH / 2;
+    float centerX, centerY;
+    calculateImagePointScreenPosition(static_cast<float>(pos.x), static_cast<float>(pos.y), srcRect, dstRect,
+        centerX, centerY);
+    innerX = static_cast<int>(centerX - innerW / 2);
+    innerY = static_cast<int>(centerY - innerH / 2);
 }
 
 void MapWidget::addLocation(const std::string& id, Point&& point)
@@ -514,6 +539,21 @@ void MapWidget::setLocationHighlight(const std::string& id, Highlight highlight,
     if (it != _locations.end() && it->second.pos.size() >= n) {
         it->second.pos[n].highlight = highlight;
     }
+}
+
+void MapWidget::setMarker(const std::string& id, const float x, const float y)
+{
+    _markers[id] = {x, y};
+}
+
+void MapWidget::clearMarker(const std::string& id)
+{
+    _markers.erase(id);
+}
+
+void MapWidget::clearMarkers()
+{
+    _markers.clear();
 }
 
 std::tuple<float, float> MapWidget::getPanCenter() const

--- a/src/ui/mapwidget.cpp
+++ b/src/ui/mapwidget.cpp
@@ -392,13 +392,13 @@ void MapWidget::render(Renderer renderer, const int offX, const int offY)
         }
     }
 
-    const Color markerColor = {0xff, 0xff, 0xff, 0xff};
     for (const auto& [id, marker] : _markers) {
         (void)id;
         float centerX, centerY;
         calculateImagePointScreenPosition(marker.x, marker.y, srcRect, dstRect, centerX, centerY);
         const int innerX = static_cast<int>(centerX - MARKER_SIZE / 2.0f);
         const int innerY = static_cast<int>(centerY - MARKER_SIZE / 2.0f);
+        const Color& markerColor = marker.appearance.color;
         drawDiamond(renderer, {innerX, innerY}, {MARKER_SIZE, MARKER_SIZE}, MARKER_BORDER_SIZE,
             markerColor, markerColor, markerColor, markerColor);
     }
@@ -543,7 +543,12 @@ void MapWidget::setLocationHighlight(const std::string& id, Highlight highlight,
 
 void MapWidget::setMarker(const std::string& id, const float x, const float y)
 {
-    _markers[id] = {x, y};
+    setMarker(id, x, y, {});
+}
+
+void MapWidget::setMarker(const std::string& id, const float x, const float y, MarkerAppearance appearance)
+{
+    _markers[id] = {x, y, appearance};
 }
 
 void MapWidget::clearMarker(const std::string& id)

--- a/src/ui/mapwidget.h
+++ b/src/ui/mapwidget.h
@@ -32,9 +32,19 @@ public:
         std::vector<Point> pos;
     };
 
+    struct MarkerAppearance {
+        enum class Type {
+            DIAMOND,
+        };
+
+        Type type = Type::DIAMOND;
+        Color color = {0xff, 0xff, 0xff, 0xff};
+    };
+
     struct Marker {
         float x = 0.0f;
         float y = 0.0f;
+        MarkerAppearance appearance;
     };
 
     // TODO: enum location state
@@ -43,6 +53,7 @@ public:
     void setLocationHighlight(const std::string& name, Highlight highlight, size_t n);
 
     void setMarker(const std::string& id, float x, float y);
+    void setMarker(const std::string& id, float x, float y, MarkerAppearance appearance);
     void clearMarker(const std::string& id);
     void clearMarkers();
 

--- a/src/ui/mapwidget.h
+++ b/src/ui/mapwidget.h
@@ -32,10 +32,19 @@ public:
         std::vector<Point> pos;
     };
 
+    struct Marker {
+        float x = 0.0f;
+        float y = 0.0f;
+    };
+
     // TODO: enum location state
     void addLocation(const std::string& name, Point&& point);
     void setLocationState(const std::string& name, int state, size_t n);
     void setLocationHighlight(const std::string& name, Highlight highlight, size_t n);
+
+    void setMarker(const std::string& id, float x, float y);
+    void clearMarker(const std::string& id);
+    void clearMarkers();
 
     // FIXME: this does not work if name is not unique
     Signal<const std::string&,int,int> onLocationHover; // FIXME: we should provide absolute AND relative mouse position through the Event stack
@@ -62,6 +71,7 @@ protected:
     int _absX=0;
     int _absY=0;
     std::map<std::string, Location> _locations;
+    std::map<std::string, Marker> _markers;
     std::optional<std::string> _locationHover; // TODO: store iterator instead of string?
 
     bool _hideClearedLocations = false;
@@ -89,6 +99,8 @@ private:
     /// Calling while .width or .height of size or autoSize is <1 is undefined.
     void calculateSrcAndDst(int offX, int offY, bool clip, float& baseScale, SDL_Rect& srcRect,
         SDL_FRect& dstRect) const;
+    static void calculateImagePointScreenPosition(float x, float y, const SDL_Rect& srcRect,
+        const SDL_FRect& dstRect, float& screenX, float& screenY);
     static void calculateLocationScreenRect(const Point& pos, const SDL_Rect& srcRect, const SDL_FRect& dstRect,
         float baseScale, int& innerX, int& innerY, int& innerW, int& innerH, int& borderSize);
 };

--- a/src/ui/trackerview.cpp
+++ b/src/ui/trackerview.cpp
@@ -1,4 +1,7 @@
 #include "trackerview.h"
+#include <cerrno>
+#include <cmath>
+#include <cstdlib>
 #include <string>
 #include <vector>
 #include <fmt/format.h>
@@ -25,6 +28,57 @@ namespace Ui {
 
 
 constexpr int TOOL_MAX_DISPLACEMENT=5; // can be off by this amount
+
+enum class MapMarkerHintAction {
+    INVALID,
+    CLEAR,
+    SET,
+};
+
+struct MapMarkerHint {
+    MapMarkerHintAction action = MapMarkerHintAction::INVALID;
+    std::string id;
+    float x = 0.0f;
+    float y = 0.0f;
+};
+
+static bool parseMapMarkerCoordinate(const std::string& field, float& result)
+{
+    if (field.empty())
+        return false;
+
+    errno = 0;
+    char* end = nullptr;
+    const float value = std::strtof(field.c_str(), &end);
+    if (end == field.c_str() || *end != '\0' || errno == ERANGE || !std::isfinite(value))
+        return false;
+
+    result = value;
+    return true;
+}
+
+static MapMarkerHint parseMapMarkerHint(const std::string& value)
+{
+    const size_t firstComma = value.find(',');
+    if (firstComma == std::string::npos)
+        return value.empty() ? MapMarkerHint{} : MapMarkerHint{MapMarkerHintAction::CLEAR, value};
+
+    const size_t secondComma = value.find(',', firstComma + 1);
+    if (firstComma == 0 || secondComma == std::string::npos ||
+            value.find(',', secondComma + 1) != std::string::npos) {
+        return {};
+    }
+
+    MapMarkerHint hint;
+    hint.id = value.substr(0, firstComma);
+    if (!parseMapMarkerCoordinate(value.substr(firstComma + 1, secondComma - firstComma - 1), hint.x) ||
+        !parseMapMarkerCoordinate(value.substr(secondComma + 1), hint.y)) {
+        return {};
+    }
+
+    hint.action = MapMarkerHintAction::SET;
+    return hint;
+}
 
 static std::list<ImageFilter> imageModsToFilters(const Tracker* tracker, const std::list<std::string>& mods)
 {
@@ -938,6 +992,7 @@ bool TrackerView::addLayoutNode(Container* container, const LayoutNode& node, si
                 if (name == "reset") {
                     w->setZoom(1);
                     w->setPan(0, 0);
+                    w->clearMarkers();
                 } else if (name.rfind("Zoom ", 0) == 0 &&
                         (name.substr(5) == mapname || name.substr(5) == numberedMapName)) {
                     size_t next = 0;
@@ -953,6 +1008,14 @@ bool TrackerView::addLayoutNode(Container* container, const LayoutNode& node, si
                         if (next) {
                             w->setPanCenter(panCenterX, panCenterY);
                         }
+                    }
+                } else if (name.rfind("MapMarker ", 0) == 0 &&
+                        (name.substr(10) == mapname || name.substr(10) == numberedMapName)) {
+                    const MapMarkerHint hint = parseMapMarkerHint(value);
+                    if (hint.action == MapMarkerHintAction::SET) {
+                        w->setMarker(hint.id, hint.x, hint.y);
+                    } else if (hint.action == MapMarkerHintAction::CLEAR) {
+                        w->clearMarker(hint.id);
                     }
                 }
             }};

--- a/src/ui/trackerview.cpp
+++ b/src/ui/trackerview.cpp
@@ -1,7 +1,8 @@
 #include "trackerview.h"
-#include <cerrno>
+#include <algorithm>
 #include <cmath>
-#include <cstdlib>
+#include <limits>
+#include <set>
 #include <string>
 #include <vector>
 #include <fmt/format.h>
@@ -31,7 +32,7 @@ constexpr int TOOL_MAX_DISPLACEMENT=5; // can be off by this amount
 
 enum class MapMarkerHintAction {
     INVALID,
-    CLEAR,
+    REMOVE,
     SET,
 };
 
@@ -40,44 +41,112 @@ struct MapMarkerHint {
     std::string id;
     float x = 0.0f;
     float y = 0.0f;
+    MapWidget::MarkerAppearance appearance;
 };
 
-static bool parseMapMarkerCoordinate(const std::string& field, float& result)
+static bool hasOnlyFields(const nlohmann::json& object, const std::set<std::string>& fields)
 {
-    if (field.empty())
-        return false;
-
-    errno = 0;
-    char* end = nullptr;
-    const float value = std::strtof(field.c_str(), &end);
-    if (end == field.c_str() || *end != '\0' || errno == ERANGE || !std::isfinite(value))
-        return false;
-
-    result = value;
+    for (auto field = object.begin(); field != object.end(); ++field) {
+        if (fields.count(field.key()) == 0)
+            return false;
+    }
     return true;
+}
+
+static bool parseMapMarkerCoordinate(const nlohmann::json& field, float& result)
+{
+    if (!field.is_number())
+        return false;
+    const double number = field.get<double>();
+    if (!std::isfinite(number) || number < -std::numeric_limits<float>::max() ||
+            number > std::numeric_limits<float>::max())
+        return false;
+    result = static_cast<float>(number);
+    return std::isfinite(result);
+}
+
+static bool isMapMarkerColor(const std::string& color)
+{
+    if (color.size() != 7 && color.size() != 9)
+        return false;
+    return color.front() == '#' && std::all_of(color.begin() + 1, color.end(), [](const unsigned char c) {
+        return std::isxdigit(c) != 0;
+    });
+}
+
+static nlohmann::json parseMapMarkerJson(const std::string& value)
+{
+    bool hasDuplicate = false;
+    std::vector<std::set<std::string>> keys;
+    const auto callback = [&hasDuplicate, &keys](const int depth, const nlohmann::json::parse_event_t event,
+            nlohmann::json& parsed) {
+        if (event == nlohmann::json::parse_event_t::object_start) {
+            const size_t keyDepth = static_cast<size_t>(depth) + 1;
+            if (keys.size() <= keyDepth)
+                keys.resize(keyDepth + 1);
+            keys[keyDepth].clear();
+        } else if (event == nlohmann::json::parse_event_t::key) {
+            const size_t keyDepth = static_cast<size_t>(depth);
+            if (keys.size() <= keyDepth)
+                keys.resize(keyDepth + 1);
+            if (!keys[keyDepth].insert(parsed.get<std::string>()).second)
+                hasDuplicate = true;
+        }
+        return true;
+    };
+    auto json = nlohmann::json::parse(value, callback, false);
+    return hasDuplicate ? nlohmann::json(nlohmann::json::value_t::discarded) : json;
 }
 
 static MapMarkerHint parseMapMarkerHint(const std::string& value)
 {
-    const size_t firstComma = value.find(',');
-    if (firstComma == std::string::npos)
-        return value.empty() ? MapMarkerHint{} : MapMarkerHint{MapMarkerHintAction::CLEAR, value};
+    try {
+        const auto json = parseMapMarkerJson(value);
+        if (json.is_discarded() || !json.is_object() ||
+                !hasOnlyFields(json, {"id", "x", "y", "remove", "appearance"}))
+            return {};
 
-    const size_t secondComma = value.find(',', firstComma + 1);
-    if (firstComma == 0 || secondComma == std::string::npos ||
-            value.find(',', secondComma + 1) != std::string::npos) {
+        const auto id = json.find("id");
+        if (id == json.end() || !id->is_string() || id->get_ref<const std::string&>().empty())
+            return {};
+
+        MapMarkerHint hint;
+        hint.id = id->get<std::string>();
+
+        const auto remove = json.find("remove");
+        if (remove != json.end()) {
+            if (json.size() != 2 || !remove->is_boolean() || !remove->get<bool>())
+                return {};
+            hint.action = MapMarkerHintAction::REMOVE;
+            return hint;
+        }
+
+        const auto x = json.find("x");
+        const auto y = json.find("y");
+        if (x == json.end() || y == json.end() ||
+                !parseMapMarkerCoordinate(*x, hint.x) || !parseMapMarkerCoordinate(*y, hint.y))
+            return {};
+
+        const auto appearance = json.find("appearance");
+        if (appearance != json.end()) {
+            if (!appearance->is_object() || !hasOnlyFields(*appearance, {"type", "color"}))
+                return {};
+            const auto type = appearance->find("type");
+            if (type == appearance->end() || !type->is_string() || type->get<std::string>() != "diamond")
+                return {};
+            const auto color = appearance->find("color");
+            if (color != appearance->end()) {
+                if (!color->is_string() || !isMapMarkerColor(color->get_ref<const std::string&>()))
+                    return {};
+                hint.appearance.color = Widget::Color(color->get<std::string>());
+            }
+        }
+
+        hint.action = MapMarkerHintAction::SET;
+        return hint;
+    } catch (...) {
         return {};
     }
-
-    MapMarkerHint hint;
-    hint.id = value.substr(0, firstComma);
-    if (!parseMapMarkerCoordinate(value.substr(firstComma + 1, secondComma - firstComma - 1), hint.x) ||
-        !parseMapMarkerCoordinate(value.substr(secondComma + 1), hint.y)) {
-        return {};
-    }
-
-    hint.action = MapMarkerHintAction::SET;
-    return hint;
 }
 
 static std::list<ImageFilter> imageModsToFilters(const Tracker* tracker, const std::list<std::string>& mods)
@@ -1013,8 +1082,8 @@ bool TrackerView::addLayoutNode(Container* container, const LayoutNode& node, si
                         (name.substr(10) == mapname || name.substr(10) == numberedMapName)) {
                     const MapMarkerHint hint = parseMapMarkerHint(value);
                     if (hint.action == MapMarkerHintAction::SET) {
-                        w->setMarker(hint.id, hint.x, hint.y);
-                    } else if (hint.action == MapMarkerHintAction::CLEAR) {
+                        w->setMarker(hint.id, hint.x, hint.y, hint.appearance);
+                    } else if (hint.action == MapMarkerHintAction::REMOVE) {
                         w->clearMarker(hint.id);
                     }
                 }

--- a/test/ui/test_mapwidget.cpp
+++ b/test/ui/test_mapwidget.cpp
@@ -1,0 +1,274 @@
+#include <algorithm>
+#include <cstdlib>
+#include <string>
+#include <vector>
+#include <gtest/gtest.h>
+
+#include "../../lib/luaglue/lua_include.h"
+#include "../../src/ui/mapwidget.h"
+#include "../../src/ui/trackerview.h"
+#include "../uilib/font_helper.h"
+
+namespace {
+
+constexpr char IMAGE_PATH[] = "examples/zoom-pan-test/images/map.png";
+constexpr char PACK_PATH[] = "examples/zoom-pan-test";
+constexpr int SURFACE_WIDTH = 240;
+constexpr int SURFACE_HEIGHT = 120;
+
+class TestTrackerView : public Ui::TrackerView {
+public:
+    explicit TestTrackerView(Tracker* tracker)
+        : TrackerView(0, 0, SURFACE_WIDTH, SURFACE_HEIGHT, tracker, "tracker_default", &fontStore)
+    {
+    }
+
+    Ui::MapWidget* map(const std::string& name, const size_t index = 0)
+    {
+        auto it = _maps.find(name);
+        if (it == _maps.end() || index >= it->second.size())
+            return nullptr;
+        auto widget = it->second.begin();
+        std::advance(widget, static_cast<long>(index));
+        return *widget;
+    }
+
+    bool addDuplicateMapNode()
+    {
+        return addLayoutNode(this, LayoutNode::FromJSON({
+            {"type", "map"},
+            {"maps", {"map", "map"}},
+        }));
+    }
+};
+
+class SoftwareRenderer {
+public:
+    SoftwareRenderer()
+    {
+        surface = SDL_CreateRGBSurfaceWithFormat(0, SURFACE_WIDTH, SURFACE_HEIGHT, 32, SDL_PIXELFORMAT_RGBA32);
+        if (!surface)
+            throw std::runtime_error("failed to create surface");
+        renderer = SDL_CreateSoftwareRenderer(surface);
+        if (!renderer) {
+            SDL_FreeSurface(surface);
+            throw std::runtime_error("failed to create renderer");
+        }
+    }
+
+    ~SoftwareRenderer()
+    {
+        SDL_DestroyRenderer(renderer);
+        SDL_FreeSurface(surface);
+    }
+
+    std::string render(Ui::MapWidget& widget)
+    {
+        SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+        SDL_RenderClear(renderer);
+        widget.render(renderer, 0, 0);
+        SDL_RenderPresent(renderer);
+        return std::string(static_cast<const char*>(surface->pixels), surface->h * surface->pitch);
+    }
+
+    SDL_Surface* surface = nullptr;
+    SDL_Renderer* renderer = nullptr;
+};
+
+struct Bounds {
+    int left = SURFACE_WIDTH;
+    int top = SURFACE_HEIGHT;
+    int right = -1;
+    int bottom = -1;
+
+    bool empty() const { return right < left || bottom < top; }
+    int width() const { return empty() ? 0 : right - left + 1; }
+    int height() const { return empty() ? 0 : bottom - top + 1; }
+};
+
+Bounds differenceBounds(const std::string& before, const std::string& after, const int pitch)
+{
+    Bounds bounds;
+    for (int y = 0; y < SURFACE_HEIGHT; ++y) {
+        for (int x = 0; x < SURFACE_WIDTH; ++x) {
+            const size_t offset = static_cast<size_t>(y * pitch + x * 4);
+            if (before.compare(offset, 4, after, offset, 4) != 0) {
+                bounds.left = std::min(bounds.left, x);
+                bounds.top = std::min(bounds.top, y);
+                bounds.right = std::max(bounds.right, x);
+                bounds.bottom = std::max(bounds.bottom, y);
+            }
+        }
+    }
+    return bounds;
+}
+
+TEST(MapWidgetMarker, SetUpdateAndClearState)
+{
+    SoftwareRenderer output;
+    Ui::MapWidget widget(0, 0, 207, 100, IMAGE_PATH);
+    const std::string baseline = output.render(widget);
+
+    widget.setMarker("player", 100.25f, 50.5f);
+    EXPECT_FALSE(output.render(widget) == baseline);
+    widget.setMarker("player", 200.5f, 50.75f);
+    const std::string moved = output.render(widget);
+    Ui::MapWidget onlyMovedMarker(0, 0, 207, 100, IMAGE_PATH);
+    onlyMovedMarker.setMarker("player", 200.5f, 50.75f);
+    EXPECT_TRUE(moved == output.render(onlyMovedMarker));
+
+    widget.setMarker("spectator", 300.0f, 100.0f);
+    widget.clearMarker("player");
+    Ui::MapWidget onlySpectator(0, 0, 207, 100, IMAGE_PATH);
+    onlySpectator.setMarker("spectator", 300.0f, 100.0f);
+    EXPECT_TRUE(output.render(widget) == output.render(onlySpectator));
+
+    widget.clearMarkers();
+    EXPECT_TRUE(output.render(widget) == baseline);
+}
+
+TEST(MapWidgetMarker, RenderFollowsZoomAndPanWithFixedSize)
+{
+    SoftwareRenderer output;
+    Ui::MapWidget widget(10, 10, 207, 100, IMAGE_PATH);
+    const std::string baseline = output.render(widget);
+
+    widget.setMarker("player", 414.0f, 200.0f);
+    const Bounds normal = differenceBounds(baseline, output.render(widget), output.surface->pitch);
+    ASSERT_FALSE(normal.empty());
+
+    widget.setZoom(2.0f);
+    const std::string zoomBaseline = [&] {
+        widget.clearMarkers();
+        const std::string pixels = output.render(widget);
+        widget.setMarker("player", 414.0f, 200.0f);
+        return pixels;
+    }();
+    const Bounds zoomed = differenceBounds(zoomBaseline, output.render(widget), output.surface->pitch);
+    EXPECT_LE(std::abs(zoomed.width() - normal.width()), 1);
+    EXPECT_LE(std::abs(zoomed.height() - normal.height()), 1);
+    EXPECT_LE(std::abs((zoomed.left + zoomed.right) - (normal.left + normal.right)), 1);
+    EXPECT_LE(std::abs((zoomed.top + zoomed.bottom) - (normal.top + normal.bottom)), 1);
+
+    widget.setPanCenter(300.0f, 200.0f);
+    const std::string panBaseline = [&] {
+        widget.clearMarkers();
+        const std::string pixels = output.render(widget);
+        widget.setMarker("player", 414.0f, 200.0f);
+        return pixels;
+    }();
+    const Bounds panned = differenceBounds(panBaseline, output.render(widget), output.surface->pitch);
+    EXPECT_GT(panned.left, zoomed.left);
+    EXPECT_LE(std::abs(panned.width() - normal.width()), 1);
+    EXPECT_LE(std::abs(panned.height() - normal.height()), 1);
+}
+
+TEST(MapWidgetMarker, WidgetClipContainsOffViewportMarker)
+{
+    SoftwareRenderer output;
+    Ui::MapWidget widget(20, 20, 100, 80, IMAGE_PATH);
+    const std::string baseline = output.render(widget);
+
+    widget.setMarker("player", -10000.0f, -10000.0f);
+    EXPECT_TRUE(output.render(widget) == baseline);
+}
+
+TEST(TrackerViewMapMarkerHint, ParsesRoutesClearsAndResetsWithoutSaving)
+{
+    (void)getDefaultFont();
+    lua_State* L = luaL_newstate();
+    ASSERT_NE(L, nullptr);
+
+    {
+        Pack pack(PACK_PATH);
+        pack.setVariant("standard");
+        Tracker tracker(&pack, L);
+        ASSERT_TRUE(tracker.AddMaps("maps/maps.json"));
+        ASSERT_TRUE(tracker.AddLocations("locations/locations.json"));
+        ASSERT_TRUE(tracker.AddItems("items/items.json"));
+        ASSERT_TRUE(tracker.AddLayouts("layouts/standard.json"));
+
+        TestTrackerView view(&tracker);
+        view.relayout();
+        Ui::MapWidget* map = view.map("map");
+        ASSERT_NE(map, nullptr);
+        map->setPosition({10, 10});
+        map->setSize({207, 100});
+        map->setImage(IMAGE_PATH);
+
+        SoftwareRenderer output;
+        const std::string baseline = output.render(*map);
+
+        tracker.UiHint("MapMarker map", "player,414.5,200.25");
+        const std::string marked = output.render(*map);
+        EXPECT_FALSE(marked == baseline);
+        const auto savedHints = view.getHints();
+        EXPECT_TRUE(std::none_of(savedHints.begin(), savedHints.end(), [](const auto& hint) {
+            return hint.first.rfind("MapMarker ", 0) == 0;
+        }));
+
+        const std::vector<std::string> invalidValues = {
+            "", ",1,2", "player,1", "player,1,2,3", "player,1x,2", "player,1,2x",
+            "player,NaN,2", "player,inf,2", "player,-inf,2",
+        };
+        for (const auto& value : invalidValues) {
+            tracker.UiHint("MapMarker map", value);
+            EXPECT_TRUE(output.render(*map) == marked) << value;
+        }
+
+        tracker.UiHint("MapMarker other", "player");
+        EXPECT_TRUE(output.render(*map) == marked);
+        tracker.UiHint("MapMarker map[0]", "player");
+        EXPECT_TRUE(output.render(*map) == baseline);
+
+        tracker.UiHint("MapMarker map[0]", "player,-4.5,3.25");
+        EXPECT_FALSE(output.render(*map) == baseline);
+        tracker.UiHint("reset", "reset");
+        EXPECT_TRUE(output.render(*map) == baseline);
+    }
+
+    lua_close(L);
+}
+
+TEST(TrackerViewMapMarkerHint, UnnumberedTargetsAllAndNumberedTargetsOneInstance)
+{
+    (void)getDefaultFont();
+    lua_State* L = luaL_newstate();
+    ASSERT_NE(L, nullptr);
+
+    {
+        Pack pack(PACK_PATH);
+        pack.setVariant("standard");
+        Tracker tracker(&pack, L);
+        ASSERT_TRUE(tracker.AddMaps("maps/maps.json"));
+
+        TestTrackerView view(&tracker);
+        ASSERT_TRUE(view.addDuplicateMapNode());
+        Ui::MapWidget* first = view.map("map", 0);
+        Ui::MapWidget* second = view.map("map", 1);
+        ASSERT_NE(first, nullptr);
+        ASSERT_NE(second, nullptr);
+        for (Ui::MapWidget* map : {first, second}) {
+            map->setPosition({0, 0});
+            map->setSize({207, 100});
+            map->setImage(IMAGE_PATH);
+        }
+
+        SoftwareRenderer output;
+        const std::string firstBaseline = output.render(*first);
+        const std::string secondBaseline = output.render(*second);
+
+        tracker.UiHint("MapMarker map", "player,414,200");
+        EXPECT_FALSE(output.render(*first) == firstBaseline);
+        EXPECT_FALSE(output.render(*second) == secondBaseline);
+
+        tracker.UiHint("MapMarker map", "player");
+        tracker.UiHint("MapMarker map[0]", "player,414,200");
+        EXPECT_FALSE(output.render(*first) == firstBaseline);
+        EXPECT_TRUE(output.render(*second) == secondBaseline);
+    }
+
+    lua_close(L);
+}
+
+} // namespace

--- a/test/ui/test_mapwidget.cpp
+++ b/test/ui/test_mapwidget.cpp
@@ -173,7 +173,7 @@ TEST(MapWidgetMarker, WidgetClipContainsOffViewportMarker)
     EXPECT_TRUE(output.render(widget) == baseline);
 }
 
-TEST(TrackerViewMapMarkerHint, ParsesRoutesClearsAndResetsWithoutSaving)
+TEST(TrackerViewMapMarkerHint, ParsesJsonRoutesRemovesAndResetsWithoutSaving)
 {
     (void)getDefaultFont();
     lua_State* L = luaL_newstate();
@@ -199,29 +199,71 @@ TEST(TrackerViewMapMarkerHint, ParsesRoutesClearsAndResetsWithoutSaving)
         SoftwareRenderer output;
         const std::string baseline = output.render(*map);
 
-        tracker.UiHint("MapMarker map", "player,414.5,200.25");
+        const std::string defaultMarker = R"({"id":"player","x":414.5,"y":200.25})";
+        const std::string redMarker = R"({"id":"player","x":414.5,"y":200.25,"appearance":{"type":"diamond","color":"#ff0000"}})";
+        const std::string alphaMarker = R"({"id":"player","x":414.5,"y":200.25,"appearance":{"type":"diamond","color":"#8000ff00"}})";
+
+        tracker.UiHint("MapMarker map", defaultMarker);
+        const std::string defaultMarked = output.render(*map);
+        EXPECT_FALSE(defaultMarked == baseline);
+
+        tracker.UiHint("MapMarker map", redMarker);
         const std::string marked = output.render(*map);
-        EXPECT_FALSE(marked == baseline);
+        EXPECT_FALSE(marked == defaultMarked);
+
+        tracker.UiHint("MapMarker map", alphaMarker);
+        const std::string alphaMarked = output.render(*map);
+        EXPECT_FALSE(alphaMarked == marked);
+
+        // Set operations completely replace the appearance rather than retaining it.
+        tracker.UiHint("MapMarker map", defaultMarker);
+        EXPECT_TRUE(output.render(*map) == defaultMarked);
+        tracker.UiHint("MapMarker map", redMarker);
+        EXPECT_TRUE(output.render(*map) == marked);
+
         const auto savedHints = view.getHints();
         EXPECT_TRUE(std::none_of(savedHints.begin(), savedHints.end(), [](const auto& hint) {
             return hint.first.rfind("MapMarker ", 0) == 0;
         }));
 
         const std::vector<std::string> invalidValues = {
-            "", ",1,2", "player,1", "player,1,2,3", "player,1x,2", "player,1,2x",
-            "player,NaN,2", "player,inf,2", "player,-inf,2",
+            "", "not JSON", "[]", "null", "{}",
+            R"({"id":"","x":1,"y":2})", R"({"id":1,"x":1,"y":2})",
+            R"({"id":"player","x":1})", R"({"id":"player","y":2})",
+            R"({"id":"player","x":"1","y":2})", R"({"id":"player","x":true,"y":2})",
+            R"({"id":"player","x":null,"y":2})", R"({"id":"player","x":[],"y":2})",
+            R"({"id":"player","x":1,"y":"2"})", R"({"id":"player","x":1,"y":false})",
+            R"({"id":"player","x":NaN,"y":2})", R"({"id":"player","x":Infinity,"y":2})",
+            R"({"id":"player","x":-Infinity,"y":2})", R"({"id":"player","x":3.5e38,"y":2})",
+            R"({"id":"player","x":1,"y":3.5e38})", R"({"id":"player","x":1e400,"y":2})",
+            R"({"id":"player","remove":false})", R"({"id":"player","remove":"true"})",
+            R"({"id":"player","remove":true,"x":1,"y":2})", R"({"id":"player","extra":true,"x":1,"y":2})",
+            R"({"id":"player","x":1,"y":2,"label":"not yet supported"})",
+            R"({"id":"player","id":"other","x":1,"y":2})",
+            R"({"id":"player","x":1,"y":2,"appearance":null})",
+            R"({"id":"player","x":1,"y":2,"appearance":{}})",
+            R"({"id":"player","x":1,"y":2,"appearance":{"type":1}})",
+            R"({"id":"player","x":1,"y":2,"appearance":{"type":"circle"}})",
+            R"({"id":"player","x":1,"y":2,"appearance":{"type":"diamond","color":1}})",
+            R"({"id":"player","x":1,"y":2,"appearance":{"type":"diamond","color":"ff0000"}})",
+            R"({"id":"player","x":1,"y":2,"appearance":{"type":"diamond","color":"#f00"}})",
+            R"({"id":"player","x":1,"y":2,"appearance":{"type":"diamond","color":"#ff000"}})",
+            R"({"id":"player","x":1,"y":2,"appearance":{"type":"diamond","color":"#ff000g"}})",
+            R"({"id":"player","x":1,"y":2,"appearance":{"type":"diamond","type":"diamond"}})",
+            R"({"id":"player","x":1,"y":2,"appearance":{"type":"diamond","color":"#12ff0000","path":"images/player.png"}})",
         };
         for (const auto& value : invalidValues) {
-            tracker.UiHint("MapMarker map", value);
+            EXPECT_NO_THROW(tracker.UiHint("MapMarker map", value));
             EXPECT_TRUE(output.render(*map) == marked) << value;
         }
 
-        tracker.UiHint("MapMarker other", "player");
+        tracker.UiHint("MapMarker other", R"({"id":"player","remove":true})");
         EXPECT_TRUE(output.render(*map) == marked);
-        tracker.UiHint("MapMarker map[0]", "player");
+        tracker.UiHint("MapMarker map[0]", R"({"id":"player","remove":true})");
         EXPECT_TRUE(output.render(*map) == baseline);
 
-        tracker.UiHint("MapMarker map[0]", "player,-4.5,3.25");
+        // Coordinates remain valid when fractional or outside the map image.
+        tracker.UiHint("MapMarker map[0]", R"({"id":"player","x":-4.5,"y":3.25})");
         EXPECT_FALSE(output.render(*map) == baseline);
         tracker.UiHint("reset", "reset");
         EXPECT_TRUE(output.render(*map) == baseline);
@@ -258,12 +300,12 @@ TEST(TrackerViewMapMarkerHint, UnnumberedTargetsAllAndNumberedTargetsOneInstance
         const std::string firstBaseline = output.render(*first);
         const std::string secondBaseline = output.render(*second);
 
-        tracker.UiHint("MapMarker map", "player,414,200");
+        tracker.UiHint("MapMarker map", R"({"id":"player","x":414,"y":200})");
         EXPECT_FALSE(output.render(*first) == firstBaseline);
         EXPECT_FALSE(output.render(*second) == secondBaseline);
 
-        tracker.UiHint("MapMarker map", "player");
-        tracker.UiHint("MapMarker map[0]", "player,414,200");
+        tracker.UiHint("MapMarker map", R"({"id":"player","remove":true})");
+        tracker.UiHint("MapMarker map[0]", R"({"id":"player","x":414,"y":200})");
         EXPECT_FALSE(output.render(*first) == firstBaseline);
         EXPECT_TRUE(output.render(*second) == secondBaseline);
     }


### PR DESCRIPTION
## Summary
- replace the comma-separated MapMarker hint payload with one strict JSON object format
- support default and colored diamond marker appearances with strict #RRGGBB / #AARRGGBB validation
- support explicit marker removal while preserving routing and transient-state behavior
- document the JSON-only contract and expand validation/routing/reset tests

## Tests
- `MapWidgetMarker.*:TrackerViewMapMarkerHint.*` (5 passed)
- full non-network suite with `-HTTP.*` (396 passed, 1 skipped)

The three HTTP tests were excluded because DNS/network access is unavailable in the sandbox.