### PR TITLE
Add Final Fantasy VIII (Archipelago) pack

### DIFF
--- a/community-packs.json
+++ b/community-packs.json
@@ -151,5 +151,14 @@
         "versions_url": "https://raw.githubusercontent.com/snileaf/CloverPit-poptracker/versions/versions.json",
         "icon_url": "https://raw.githubusercontent.com/snileaf/CloverPit-poptracker/versions/CloverPit.png",
         "description":  "The CloverPit Archipelago PopTracker Pack."
+    },
+    "ff8_archipelago": {
+        "name": "Final Fantasy VIII (Archipelago)",
+        "author": "ff8_arch",
+        "platform": "pc",
+        "homepage": "https://github.com/wilsonao/ff8_arch",
+        "versions_url": "https://raw.githubusercontent.com/wilsonao/ff8_arch/main/tracker/versions.json",
+        "icon_url": "https://raw.githubusercontent.com/wilsonao/ff8_arch/main/tracker/ff8_ap_tracker/images/gf_ifrit.png",
+        "description":  "Map + item tracker for the Final Fantasy VIII (Steam 2013) Archipelago world, with AP autotracking."
     }
 }


### PR DESCRIPTION
Adds the PopTracker pack for the Final Fantasy VIII (Steam 2013) Archipelago world.

Checklist:
- key `ff8_archipelago` matches `package_uid` in the pack's `manifest.json`
- `versions_url` is https and serves a valid versions file with the released zip's sha256
- `name` / `author` / `platform` match the manifest of the latest download (`Final Fantasy VIII (Archipelago)` / `ff8_arch` / `pc`)
- `icon_url` is a 32x32 PNG
- I am the author of the pack

Pack home: https://github.com/wilsonao/ff8_arch (release: https://github.com/wilsonao/ff8_arch/releases/tag/v0.1.0)