### PR TITLE
Add HintItem and HintLocation commands for Archipelago

### DIFF
--- a/api/lua/definition/poptracker.lua
+++ b/api/lua/definition/poptracker.lua
@@ -443,15 +443,17 @@ function Archipelago:LocationChecks(locations) end
 ---@return boolean true on success
 function Archipelago:LocationScouts(locations, sendAsHint) end
 
----Asks the server for an item hint
----@param id integer
+---Asks the server for an item hint.
+---Shortcut for using the !hint command.
+---@param item string either ID or name
 ---@return boolean true on success
-function Archipelago:HintItem(id) end
+function Archipelago:HintItem(item) end
 
----Asks the server for a location hint
----@param id integer
+---Asks the server for a location hint.
+---Shortcut for using the !hint_location command.
+---@param location string either ID or name
 ---@return boolean true on success
-function Archipelago:HintLocation(id) end
+function Archipelago:HintLocation(location) end
 
 ---Send client status to the server. This is used to send the goal / win condition.
 ---Supported since 0.27.1, only allowed if "apmanual" flag is set in manifest.

--- a/api/lua/definition/poptracker.lua
+++ b/api/lua/definition/poptracker.lua
@@ -443,6 +443,16 @@ function Archipelago:LocationChecks(locations) end
 ---@return boolean true on success
 function Archipelago:LocationScouts(locations, sendAsHint) end
 
+---Asks the server for an item hint
+---@param id integer
+---@return boolean true on success
+function Archipelago:HintItem(id) end
+
+---Asks the server for a location hint
+---@param id integer
+---@return boolean true on success
+function Archipelago:HintLocation(id) end
+
 ---Send client status to the server. This is used to send the goal / win condition.
 ---Supported since 0.27.1, only allowed if "apmanual" flag is set in manifest.
 ---@param status archipelagoCientStatus

--- a/src/ap/aptracker.h
+++ b/src/ap/aptracker.h
@@ -358,6 +358,20 @@ public:
         return _ap->LocationScouts(locations, createAsHint);
     }
 
+    bool HintItem(int id)
+    {
+        if (!_ap)
+            return false;
+        return _ap->Say("!hint " + std::to_string(id));
+    }
+
+    bool HintLocation(int id)
+    {
+        if (!_ap)
+            return false;
+        return _ap->Say("!hint_location " + std::to_string(id));
+    }
+
     /// Returns true if sending a client status update to the server.
     /// This is used to send the goal / win condition.
     bool StatusUpdate(APClient::ClientStatus status)

--- a/src/ap/aptracker.h
+++ b/src/ap/aptracker.h
@@ -358,18 +358,18 @@ public:
         return _ap->LocationScouts(locations, createAsHint);
     }
 
-    bool HintItem(int id)
+    bool HintItem(const std::string& item)
     {
         if (!_ap)
             return false;
-        return _ap->Say("!hint " + std::to_string(id));
+        return _ap->Say("!hint " + item);
     }
 
-    bool HintLocation(int id)
+    bool HintLocation(const std::string& location)
     {
         if (!_ap)
             return false;
-        return _ap->Say("!hint_location " + std::to_string(id));
+        return _ap->Say("!hint_location " + location);
     }
 
     /// Returns true if sending a client status update to the server.

--- a/src/ap/aptracker.h
+++ b/src/ap/aptracker.h
@@ -358,6 +358,7 @@ public:
         return _ap->LocationScouts(locations, createAsHint);
     }
 
+    /// Returns true if message was sent to the server
     bool HintItem(const std::string& item)
     {
         if (!_ap)
@@ -365,6 +366,7 @@ public:
         return _ap->Say("!hint " + item);
     }
 
+    /// Returns true if message was sent to the server
     bool HintLocation(const std::string& location)
     {
         if (!_ap)

--- a/src/ap/archipelago.cpp
+++ b/src/ap/archipelago.cpp
@@ -19,8 +19,8 @@ const LuaInterface<Archipelago>::MethodMap Archipelago::Lua_Methods = {
     LUA_METHOD(Archipelago, Get, json),
     LUA_METHOD(Archipelago, LocationChecks, json),
     LUA_METHOD(Archipelago, LocationScouts, json, int),
-    LUA_METHOD(Archipelago, HintItem, int),
-    LUA_METHOD(Archipelago, HintLocation, int),
+    LUA_METHOD(Archipelago, HintItem, const char*),
+    LUA_METHOD(Archipelago, HintLocation, const char*),
     LUA_METHOD(Archipelago, StatusUpdate, int),
 
     LUA_METHOD(Archipelago, GetPlayerAlias, int),
@@ -307,18 +307,18 @@ bool Archipelago::LocationScouts(const json &jLocations, int sendAsHint)
     return _ap->LocationScouts(locations, sendAsHint);
 }
 
-bool Archipelago::HintItem(int id)
+bool Archipelago::HintItem(const std::string& item)
 {
     if (!_ap)
         return false;
-    return _ap->HintItem(id);
+    return _ap->HintItem(item);
 }
 
-bool Archipelago::HintLocation(int id)
+bool Archipelago::HintLocation(const std::string& location)
 {
     if (!_ap)
         return false;
-    return _ap->HintLocation(id);
+    return _ap->HintLocation(location);
 }
 
 bool Archipelago::StatusUpdate(int status)

--- a/src/ap/archipelago.cpp
+++ b/src/ap/archipelago.cpp
@@ -19,6 +19,8 @@ const LuaInterface<Archipelago>::MethodMap Archipelago::Lua_Methods = {
     LUA_METHOD(Archipelago, Get, json),
     LUA_METHOD(Archipelago, LocationChecks, json),
     LUA_METHOD(Archipelago, LocationScouts, json, int),
+    LUA_METHOD(Archipelago, HintItem, int),
+    LUA_METHOD(Archipelago, HintLocation, int),
     LUA_METHOD(Archipelago, StatusUpdate, int),
 
     LUA_METHOD(Archipelago, GetPlayerAlias, int),
@@ -303,6 +305,20 @@ bool Archipelago::LocationScouts(const json &jLocations, int sendAsHint)
         }
     }
     return _ap->LocationScouts(locations, sendAsHint);
+}
+
+bool Archipelago::HintItem(int id)
+{
+    if (!_ap)
+        return false;
+    return _ap->HintItem(id);
+}
+
+bool Archipelago::HintLocation(int id)
+{
+    if (!_ap)
+        return false;
+    return _ap->HintLocation(id);
 }
 
 bool Archipelago::StatusUpdate(int status)

--- a/src/ap/archipelago.h
+++ b/src/ap/archipelago.h
@@ -28,8 +28,8 @@ public:
     bool Get(const json& keys);
     bool LocationChecks(const json& locations);
     bool LocationScouts(const json& locations, int sendAsHint);
-    bool HintItem(int id);
-    bool HintLocation(int id);
+    bool HintItem(const std::string& item);
+    bool HintLocation(const std::string& location);
     bool StatusUpdate(int status);
 
     std::string GetPlayerAlias(int slot);

--- a/src/ap/archipelago.h
+++ b/src/ap/archipelago.h
@@ -28,6 +28,8 @@ public:
     bool Get(const json& keys);
     bool LocationChecks(const json& locations);
     bool LocationScouts(const json& locations, int sendAsHint);
+    bool HintItem(int id);
+    bool HintLocation(int id);
     bool StatusUpdate(int status);
 
     std::string GetPlayerAlias(int slot);


### PR DESCRIPTION
## What does this feature do
Adds Archipelago:HintItem and Archipelago:HintLocation functions. These will just use the pre-existing Say command to post `!hint [item]` and `!hint_location [location]` to the server.

## Why is this feature wanted
The current hint functions either only work with the apmanual flag or will ignore AP's hint costs. For people using a tracker that doesn't have item or location names that match exactly what AP expects, it can be a chore to find the correct name. This way the tracker can send the correct names, or even IDs, to the server without the user having to find the info by digging through GitHub or DataPackage.

## How was this tested
- With no locations checked and AP hint cost 15%, I ran both of these functions in OnClear. They correctly returned true and did not create a hint on the server
- With no locations checked and AP hint cost 0%, I ran both of these functions in OnClear. They correctly returned true and created a hint, and my section highlights updated
- I ran both of these functions in init.lua, and they both correctly returned false as the slot was not connected yet

## Potential improvements
- apclient.hpp has this line (1091) for its Say function: `if (_state < State::ROOM_INFO) // or SLOT_CONNECTED?`. I am also unsure how much this matters because as far as I know PopTracker shouldn't ever be in ROOM_INFO state (at least that we can interact with) since the slot is required to connect, but it's possible this should be changed to SLOT_CONNECTED anyway
- Currently if the Say command is successful, but a hint was not created because the user doesn't have enough hint points or the item/location does not exist, there is no feedback we can use to display to the user. I am unaware if there's an API response we can listen to for this, but if there is it could be useful since the only feedback currently is literally nothing happening. I had a text client open while testing, and the usual "You don't have enough hint points" message didn't post, I assume because it only responds to the specific connection that requested it, not any client with that slot connected